### PR TITLE
Ручные запуски workflow

### DIFF
--- a/.github/scripts/analytics/flaky_tests_history.py
+++ b/.github/scripts/analytics/flaky_tests_history.py
@@ -180,6 +180,7 @@ def build_history_query(date, test_runs_table, testowners_table, build_type, bra
                         ) 
                         and build_type = '{build_type}'
                         and branch = '{branch}'
+                        and (pull IS NULL OR NOT String::Contains(pull, 'manual'))
                     order by full_name,run_timestamp desc
                 ) as hist
                 ON test_and_date.full_name=hist.full_name

--- a/.github/scripts/analytics/upload_testowners.py
+++ b/.github/scripts/analytics/upload_testowners.py
@@ -59,6 +59,7 @@ def main():
             'Postcommit_relwithdebinfo', 
             'Postcommit_asan'
         ) 
+        and (pull IS NULL OR NOT String::Contains(pull, 'manual'))
         WINDOW w AS (
             PARTITION BY test_name, 
             suite_folder 

--- a/.github/scripts/tests/get_muted_tests.py
+++ b/.github/scripts/tests/get_muted_tests.py
@@ -64,6 +64,7 @@ def get_all_tests(job_id=None, branch=None, build_type=None):
                 job_id = {job_id} 
                 and branch = '{branch}'
                 and run_timestamp >= CurrentUtcDate() - 30*Interval("P1D")
+                and (pull IS NULL OR NOT String::Contains(pull, 'manual'))
         )
         """
         else:  # get all tests with run_timestamp_last from test_runs_column for specific branch
@@ -88,7 +89,8 @@ def get_all_tests(job_id=None, branch=None, build_type=None):
             FROM `{test_runs_table}`
             WHERE branch = '{branch}'
             AND build_type = '{build_type}'
-            and  run_timestamp >= CurrentUtcDate() - 90*Interval("P1D")
+            and run_timestamp >= CurrentUtcDate() - 90*Interval("P1D")
+            and (pull IS NULL OR NOT String::Contains(pull, 'manual'))
             GROUP BY suite_folder, test_name
         ) trc ON t.suite_folder = trc.suite_folder AND t.test_name = trc.test_name
         """

--- a/.github/scripts/tests/get_test_history.py
+++ b/.github/scripts/tests/get_test_history.py
@@ -84,6 +84,7 @@ def get_test_history(test_names_array, days_back, build_type, branch):
         AND ($build_type = '' OR t.build_type = $build_type)
         AND ($branch = '' OR t.branch = $branch)
         AND t.job_name != 'Run-tests'
+        AND (t.pull IS NULL OR NOT String::Contains(t.pull, 'manual'))
     ORDER BY 
         test_name, 
         run_timestamp DESC;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Exclude manual workflow runs from test status aggregation in `update_muted_tests`.

### Changelog category <!-- remove all except one -->

* Improvement

### Description for reviewers <!-- (optional) description for those who read this PR -->

This change prevents manual workflow runs (e.g., `workflow_dispatch` with `_manual_attempt_N` in the `pull` field) from being included in the aggregation of test statuses. This ensures that `update_muted_tests` and `create_issues_for_muted_tests` workflows use more relevant data, excluding potentially skewed results from manual interventions. The filter `and (pull IS NULL OR NOT String::Contains(pull, 'manual'))` was added to relevant SQL queries.

<div><a href="https://cursor.com/agents/bc-350a4ad4-1ba5-48d9-aa8e-8f065b10e599"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-350a4ad4-1ba5-48d9-aa8e-8f065b10e599"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>


<!-- CURSOR_AGENT_PR_BODY_END -->