### PR TITLE
Fast-unmute override MVP: non-bot gating + hit-rate metrics

### DIFF
--- a/.github/config/fast_unmute_override_design.md
+++ b/.github/config/fast_unmute_override_design.md
@@ -1,0 +1,163 @@
+# Fast unmute override design (draft)
+
+## Context
+
+Current default policy is stable and should stay unchanged:
+
+- unmute window: **7 days**
+- no failures in window
+- issue can be closed when tests are unmuted
+
+This covers real cases where tests recover because of infra, dependency, or environment changes, without requiring a fix PR.
+
+At the same time, teams may want an **optional fast path** for selected cases.
+
+## Goals
+
+1. Keep default behavior unchanged (7-day unmute).
+2. Add an optional 1-day unmute window for explicitly approved cases.
+3. Apply fast window only to tests that were still "in scope" for an issue at close time.
+4. Avoid fragile reopen logic across multiple historical issues.
+
+## Non-goals
+
+- Replacing the default 7-day policy.
+- Requiring fix PR link for every close/unmute.
+- Mandatory reopen of old closed issues.
+
+## Signal for fast path
+
+Use an explicit, machine-readable opt-in signal on issue:
+
+- label: `fast-unmute-1d`
+
+Optional guard (recommended): issue is closed by non-bot actor.
+
+Reason:
+
+- explicit intent from humans
+- no hidden heuristics
+- easy to audit
+
+## Why not "manual muted_ya edit" as primary signal
+
+Manual `muted_ya` change is too weak semantically:
+
+- may represent temporary operational actions
+- does not necessarily mean test is fixed
+
+It may be used as fallback in future, but not as primary fast-unmute trigger.
+
+## Core rule
+
+For each issue:
+
+- `T_all`: tests from issue body (`<!--mute_list_start--> ... <!--mute_list_end-->`)
+- `T_prev_unmuted`: tests already announced as unmuted in prior comments
+- `T_remaining_before_close = T_all - T_prev_unmuted`
+
+Fast window can be applied only to `T_remaining_before_close`.
+
+This prevents retroactive impact on tests that were unmuted earlier in partial updates.
+
+## Reliable storage for "already unmuted in this issue"
+
+Do not parse free-form text. Add markers in unmute comments:
+
+```text
+Some tests have been unmuted:
+<!--unmute_list_start-->
+- Test ydb/path/test_a
+- Test ydb/path/test_b
+<!--unmute_list_end-->
+```
+
+The parser should read only marked blocks.
+
+## Persistence for overrides
+
+Introduce table: `test_results/analytics/unmute_overrides`
+
+Primary key:
+
+- `(full_name, branch, build_type)`
+
+Columns:
+
+- `full_name` Utf8 NOT NULL
+- `branch` Utf8 NOT NULL
+- `build_type` Utf8 NOT NULL
+- `window_days` Uint32 NOT NULL (for now: 1)
+- `reason` Utf8 NOT NULL (example: `issue_fast_unmute_1d`)
+- `issue_number` Uint64
+- `activated_at` Timestamp NOT NULL
+- `expires_at` Timestamp
+- `active` Uint8 NOT NULL
+- `consumed_at` Timestamp
+
+Notes:
+
+- store only active rows in hot path queries
+- set `consumed_at` when test is actually unmuted
+
+## Runtime behavior
+
+1. Default unmute logic still uses 7-day window.
+2. For tests with active override:
+   - evaluate unmute condition on 1-day aggregate
+   - keep existing thresholds (runs and failures) unless separately tuned
+3. If test gets unmuted:
+   - mark override as `active=0`
+   - set `consumed_at`
+4. If override expires before unmute:
+   - fallback to default 7-day path automatically
+
+## Integration points
+
+1. `.github/scripts/tests/update_mute_issues.py`
+   - include unmute list markers in comments
+   - extract `T_prev_unmuted` from markers
+2. `.github/scripts/tests/create_new_muted_ya.py`
+   - load active overrides
+   - aggregate 1-day and 7-day windows
+   - apply per-test window selection
+3. `.github/scripts/analytics/export_issues_to_ydb.py` (optional guard)
+   - export closed actor login to allow non-bot checks
+4. New helper module:
+   - read/write `unmute_overrides` table
+
+## Rollout
+
+Phase 1 (safe):
+
+- add comment markers + parser
+- add override table and helper code
+- no automatic override creation yet
+
+Phase 2:
+
+- create override rows only for closed issues with `fast-unmute-1d`
+- optional non-bot guard enabled
+
+Phase 3:
+
+- add dashboard card: active overrides and outcomes
+- tune thresholds if needed (for example, minimum runs for 1-day window)
+
+## Expected impact
+
+Pros:
+
+- default stable process unchanged
+- fast path is explicit and auditable
+- no fragile reopen dependency
+
+Risks:
+
+- 1-day window may still be optimistic for highly flaky tests
+- requires small amount of new state management
+
+Mitigation:
+
+- keep fast path opt-in only
+- add override expiration and consumption semantics

--- a/.github/config/mute_rules.md
+++ b/.github/config/mute_rules.md
@@ -257,3 +257,11 @@ sequenceDiagram
     W->>TG: Send messages with plots
 ```
 
+## Draft extension: optional fast unmute
+
+Default behavior remains unchanged: 7-day unmute window and normal issue lifecycle.
+
+For an opt-in fast path proposal (1-day window via explicit issue signal, with per-test overrides and safe handling of partially unmuted issue lists), see:
+
+- [fast_unmute_override_design.md](./fast_unmute_override_design.md)
+

--- a/.github/config/ydb_qa_config.json
+++ b/.github/config/ydb_qa_config.json
@@ -20,6 +20,7 @@
               "pr_blocked_by_failed_tests_rich": "test_results/analytics/pr_blocked_by_failed_tests_rich",
               "pr_blocked_by_tests": "test_results/analytics/pr_blocked_by_tests",
               "pr_check_failures_by_attempt": "test_results/analytics/pr_check_failures_by_attempt",
+              "unmute_overrides": "test_results/analytics/unmute_overrides",
               "binary_size": "binary_size",
               "issues": "github_data/issues",
               "pull_requests": "github_data/pull_requests"

--- a/.github/scripts/tests/create_new_muted_ya.py
+++ b/.github/scripts/tests/create_new_muted_ya.py
@@ -1065,6 +1065,8 @@ def mute_worker(args):
 
         logging.info(f"Starting mute worker with mode: {args.mode}")
         logging.info(f"Branch: {args.branch}")
+        build_type = getattr(args, 'build_type', 'relwithdebinfo')
+        logging.info(f"build_type: {build_type}")
         
         # Use provided muted_ya file or fallback to default.
         input_muted_ya_path = getattr(args, 'muted_ya_file', muted_ya_path)
@@ -1077,7 +1079,7 @@ def mute_worker(args):
         logging.info("Executing single query for 7 days window...")
         
         # Single query for maximum window (7 days).
-        all_data = execute_query(args.branch, days_window=7)
+        all_data = execute_query(args.branch, build_type=build_type, days_window=7)
         logging.info(f"Query returned {len(all_data)} test records")
         
         # Use unified aggregation for different periods.
@@ -1102,13 +1104,13 @@ def mute_worker(args):
             create_unmute_overrides_table(ydb_wrapper, overrides_table_path)
 
             synced_count = sync_fast_unmute_overrides(
-                ydb_wrapper, overrides_table_path, args.branch, 'relwithdebinfo'
+                ydb_wrapper, overrides_table_path, args.branch, build_type
             )
             if synced_count:
                 logging.info(f"Synced {synced_count} fast-unmute override rows")
 
             active_overrides = load_active_unmute_overrides(
-                ydb_wrapper, overrides_table_path, args.branch, 'relwithdebinfo'
+                ydb_wrapper, overrides_table_path, args.branch, build_type
             )
             logging.info(f"Loaded {len(active_overrides)} active fast-unmute overrides")
 
@@ -1134,11 +1136,26 @@ def mute_worker(args):
                 if full_name in active_overrides:
                     consumed.add(full_name)
 
+            observed_overrides = set(active_overrides).intersection(
+                {test.get('full_name') for test in aggregated_for_fast_unmute}
+            )
+            override_denominator = len(observed_overrides) or len(active_overrides)
+            override_hit_rate = (
+                (len(consumed) / override_denominator) * 100 if override_denominator else 0.0
+            )
+            logging.info(
+                "FAST_UNMUTE_OVERRIDE_METRICS: "
+                f"active={len(active_overrides)}, "
+                f"observed={len(observed_overrides)}, "
+                f"consumed={len(consumed)}, "
+                f"hit_rate={override_hit_rate:.1f}%"
+            )
+
             consumed_count = consume_unmute_overrides(
                 ydb_wrapper,
                 overrides_table_path,
                 args.branch,
-                'relwithdebinfo',
+                build_type,
                 consumed,
             )
             if consumed_count:
@@ -1162,6 +1179,7 @@ if __name__ == "__main__":
     update_muted_ya_parser = subparsers.add_parser('update_muted_ya', help='create new muted_ya')
     update_muted_ya_parser.add_argument('--output_folder', default=repo_path, required=False, help='Output folder.')
     update_muted_ya_parser.add_argument('--branch', default='main', help='Branch to get history')
+    update_muted_ya_parser.add_argument('--build_type', default='relwithdebinfo', help='Build type for monitor query')
     update_muted_ya_parser.add_argument('--muted_ya_file', default=muted_ya_path, help='Path to input muted_ya.txt file')
 
     create_issues_parser = subparsers.add_parser(
@@ -1172,6 +1190,7 @@ if __name__ == "__main__":
         '--file_path', default=f'{repo_path}/mute_update/to_mute.txt', required=False, help='file path'
     )
     create_issues_parser.add_argument('--branch', default='main', help='Branch to get history')
+    create_issues_parser.add_argument('--build_type', default='relwithdebinfo', help='Build type for monitor query')
     create_issues_parser.add_argument('--close_issues', action='store_true', default=True, help='Close issues when all tests are unmuted (default: True)')
 
     args = parser.parse_args()

--- a/.github/scripts/tests/create_new_muted_ya.py
+++ b/.github/scripts/tests/create_new_muted_ya.py
@@ -18,6 +18,7 @@ from update_mute_issues import (
     generate_github_issue_title_and_body,
     get_muted_tests_from_issues,
     close_unmuted_issues,
+    collect_fast_unmute_overrides,
 )
 
 # Add analytics directory to path for ydb_wrapper import
@@ -35,6 +36,12 @@ muted_ya_path = '.github/config/muted_ya.txt'
 MUTE_DAYS = 4
 UNMUTE_DAYS = 7
 DELETE_DAYS = 7
+FAST_UNMUTE_DAYS = 1
+UNMUTE_OVERRIDES_TABLE_NAME = "unmute_overrides"
+
+
+def _utc_now():
+    return datetime.datetime.now(datetime.timezone.utc)
 
 def is_chunk_test(test):
     # First, check the is_test_chunk field if it exists.
@@ -175,6 +182,141 @@ def add_lines_to_file(file_path, lines_to_add):
         logging.info(f"Lines added to {file_path}")
     except Exception as e:
         logging.error(f"Error adding lines to {file_path}: {e}")
+
+
+def create_unmute_overrides_table(ydb_wrapper, table_path):
+    create_sql = f"""
+        CREATE TABLE IF NOT EXISTS `{table_path}` (
+            `full_name` Utf8 NOT NULL,
+            `branch` Utf8 NOT NULL,
+            `build_type` Utf8 NOT NULL,
+            `window_days` Uint32 NOT NULL,
+            `reason` Utf8 NOT NULL,
+            `issue_number` Uint64,
+            `activated_at` Timestamp NOT NULL,
+            `expires_at` Timestamp,
+            `active` Uint8 NOT NULL,
+            `consumed_at` Timestamp,
+            PRIMARY KEY (`full_name`, `branch`, `build_type`)
+        )
+        PARTITION BY HASH(full_name)
+        WITH (STORE = COLUMN)
+    """
+    ydb_wrapper.create_table(table_path, create_sql)
+
+
+def upsert_unmute_overrides(ydb_wrapper, table_path, overrides):
+    if not overrides:
+        return 0
+
+    now = _utc_now()
+    rows = []
+    seen = set()
+    for item in overrides:
+        full_name = item.get('full_name')
+        branch = item.get('branch')
+        build_type = item.get('build_type')
+        if not full_name or not branch or not build_type:
+            continue
+        key = (full_name, branch, build_type)
+        if key in seen:
+            continue
+        seen.add(key)
+
+        rows.append(
+            {
+                'full_name': full_name,
+                'branch': branch,
+                'build_type': build_type,
+                'window_days': int(item.get('window_days', FAST_UNMUTE_DAYS)),
+                'reason': item.get('reason', 'issue_fast_unmute_1d'),
+                'issue_number': item.get('issue_number'),
+                'activated_at': now,
+                'expires_at': item.get('expires_at'),
+                'active': 1,
+                'consumed_at': None,
+            }
+        )
+
+    if not rows:
+        return 0
+
+    column_types = (
+        ydb.BulkUpsertColumns()
+        .add_column("full_name", ydb.OptionalType(ydb.PrimitiveType.Utf8))
+        .add_column("branch", ydb.OptionalType(ydb.PrimitiveType.Utf8))
+        .add_column("build_type", ydb.OptionalType(ydb.PrimitiveType.Utf8))
+        .add_column("window_days", ydb.OptionalType(ydb.PrimitiveType.Uint32))
+        .add_column("reason", ydb.OptionalType(ydb.PrimitiveType.Utf8))
+        .add_column("issue_number", ydb.OptionalType(ydb.PrimitiveType.Uint64))
+        .add_column("activated_at", ydb.OptionalType(ydb.PrimitiveType.Timestamp))
+        .add_column("expires_at", ydb.OptionalType(ydb.PrimitiveType.Timestamp))
+        .add_column("active", ydb.OptionalType(ydb.PrimitiveType.Uint8))
+        .add_column("consumed_at", ydb.OptionalType(ydb.PrimitiveType.Timestamp))
+    )
+    ydb_wrapper.bulk_upsert_batches(
+        table_path,
+        rows,
+        column_types,
+        batch_size=500,
+        query_name="upsert_unmute_overrides",
+    )
+    return len(rows)
+
+
+def load_active_unmute_overrides(ydb_wrapper, table_path, branch, build_type):
+    query = f"""
+        SELECT full_name, window_days
+        FROM `{table_path}`
+        WHERE branch = '{branch}'
+          AND build_type = '{build_type}'
+          AND active = 1
+          AND (expires_at IS NULL OR expires_at > CurrentUtcTimestamp())
+    """
+    rows = ydb_wrapper.execute_scan_query(query, query_name="load_active_unmute_overrides")
+    return {row['full_name']: int(row.get('window_days', FAST_UNMUTE_DAYS)) for row in rows}
+
+
+def consume_unmute_overrides(ydb_wrapper, table_path, branch, build_type, full_names):
+    if not full_names:
+        return 0
+
+    now = _utc_now()
+    rows = [
+        {
+            'full_name': full_name,
+            'branch': branch,
+            'build_type': build_type,
+            'active': 0,
+            'consumed_at': now,
+        }
+        for full_name in sorted(set(full_names))
+    ]
+    column_types = (
+        ydb.BulkUpsertColumns()
+        .add_column("full_name", ydb.OptionalType(ydb.PrimitiveType.Utf8))
+        .add_column("branch", ydb.OptionalType(ydb.PrimitiveType.Utf8))
+        .add_column("build_type", ydb.OptionalType(ydb.PrimitiveType.Utf8))
+        .add_column("active", ydb.OptionalType(ydb.PrimitiveType.Uint8))
+        .add_column("consumed_at", ydb.OptionalType(ydb.PrimitiveType.Timestamp))
+    )
+    ydb_wrapper.bulk_upsert_batches(
+        table_path,
+        rows,
+        column_types,
+        batch_size=500,
+        query_name="consume_unmute_overrides",
+    )
+    return len(rows)
+
+
+def sync_fast_unmute_overrides(ydb_wrapper, table_path, branch, build_type):
+    try:
+        overrides = collect_fast_unmute_overrides(branch=branch, build_type=build_type)
+    except Exception as e:
+        logging.warning(f"Failed to collect fast-unmute overrides from GitHub: {e}")
+        return 0
+    return upsert_unmute_overrides(ydb_wrapper, table_path, overrides)
 
 def aggregate_test_data(all_data, period_days):
     """Universal helper to aggregate test data for a given period."""
@@ -373,34 +515,45 @@ def is_mute_candidate(test, aggregated_data):
     
     return result
 
-def is_unmute_candidate(test, aggregated_data):
-    """Check whether a test is an unmute candidate for the given period."""
-    # Find this test in aggregated data.
-    test_data = None
-    for agg_test in aggregated_data:
-        if agg_test['full_name'] == test.get('full_name'):
-            test_data = agg_test
-            break
-    
+def is_unmute_candidate(test, aggregated_data, fast_aggregated_data=None, fast_override_days_by_test=None):
+    """Check whether a test is an unmute candidate, with optional per-test fast override."""
+    full_name = test.get('full_name')
+    fast_override_days_by_test = fast_override_days_by_test or {}
+    use_fast_window = full_name in fast_override_days_by_test and fast_aggregated_data is not None
+
+    source = fast_aggregated_data if use_fast_window else aggregated_data
+    if isinstance(source, dict):
+        test_data = source.get(full_name)
+    else:
+        test_data = None
+        for agg_test in source:
+            if agg_test['full_name'] == full_name:
+                test_data = agg_test
+                break
+
     if not test_data:
         return False
-    
+
     # Update test fields used by debug output.
     test['pass_count'] = test_data['pass_count']
     test['fail_count'] = test_data['fail_count']
     test['mute_count'] = test_data['mute_count']
     test['period_days'] = test_data.get('period_days')
     test['is_muted'] = test_data.get('is_muted', False)
-    
+
     total_runs = test_data['pass_count'] + test_data['fail_count'] + test_data['mute_count']
     total_fails = test_data['fail_count'] + test_data['mute_count']
-    
+
     result = total_runs >= 4 and total_fails == 0
-    
-    # Add detailed logging for diagnostics.
-    if test_data.get('is_muted', False):  # Log only for currently muted tests.
-        logging.debug(f"UNMUTE_CHECK: {test.get('full_name')} - runs:{total_runs}, fails:{total_fails}, mute_count:{test_data['mute_count']}, state:{test_data.get('state')}, muted:{test_data.get('is_muted')}, result:{result}")
-    
+
+    if test_data.get('is_muted', False):
+        mode = "FAST" if use_fast_window else "DEFAULT"
+        logging.debug(
+            f"UNMUTE_CHECK[{mode}]: {full_name} - runs:{total_runs}, fails:{total_fails}, "
+            f"mute_count:{test_data['mute_count']}, state:{test_data.get('state')}, "
+            f"muted:{test_data.get('is_muted')}, result:{result}"
+        )
+
     return result
 
 def is_delete_candidate(test, aggregated_data):
@@ -511,7 +664,16 @@ def write_file_set(file_path, test_set, debug_list=None, sort_without_prefixes=F
         add_lines_to_file(debug_path, [line + '\n' for line in sorted_debug_list])
     logging.info(f"Created {os.path.basename(file_path)} with {len(sorted_test_set)} tests")
 
-def apply_and_add_mutes(all_data, output_path, mute_check, aggregated_for_mute, aggregated_for_unmute, aggregated_for_delete):
+def apply_and_add_mutes(
+    all_data,
+    output_path,
+    mute_check,
+    aggregated_for_mute,
+    aggregated_for_unmute,
+    aggregated_for_delete,
+    aggregated_for_fast_unmute=None,
+    fast_override_days_by_test=None,
+):
     output_path = os.path.join(output_path, 'mute_update')
     logging.info(f"Creating mute files in directory: {output_path}")
     
@@ -533,10 +695,20 @@ def apply_and_add_mutes(all_data, output_path, mute_check, aggregated_for_mute, 
         write_file_set(os.path.join(output_path, 'to_mute.txt'), to_mute, to_mute_debug)
         
         # 2. Unmute candidates.
+        fast_override_days_by_test = fast_override_days_by_test or {}
+        aggregated_for_fast_unmute_index = {
+            test['full_name']: test for test in (aggregated_for_fast_unmute or [])
+        }
+
         def is_unmute_candidate_wrapper(test):
             if is_chunk_test(test):
                 return False  # Do not unmute chunks individually.
-            return is_unmute_candidate(test, aggregated_for_unmute)
+            return is_unmute_candidate(
+                test,
+                aggregated_for_unmute,
+                fast_aggregated_data=aggregated_for_fast_unmute_index,
+                fast_override_days_by_test=fast_override_days_by_test,
+            )
         
         # Regular unmute candidates (non-chunk tests only).
         to_unmute, to_unmute_debug = create_file_set(
@@ -546,7 +718,16 @@ def apply_and_add_mutes(all_data, output_path, mute_check, aggregated_for_mute, 
         # Wildcard unmute patterns:
         # If all pattern chunks pass the filter, unmute the whole pattern.
         # If at least one chunk fails, the pattern is not unmuted.
-        wildcard_unmute = get_wildcard_unmute_candidates(aggregated_for_unmute, mute_check, is_unmute_candidate)
+        wildcard_unmute = get_wildcard_unmute_candidates(
+            aggregated_for_unmute,
+            mute_check,
+            lambda test, _: is_unmute_candidate(
+                test,
+                aggregated_for_unmute,
+                fast_aggregated_data=aggregated_for_fast_unmute_index,
+                fast_override_days_by_test=fast_override_days_by_test,
+            ),
+        )
         wildcard_unmute_patterns = [p for p, d in wildcard_unmute]
         wildcard_unmute_debugs = [d for p, d in wildcard_unmute]
         
@@ -704,7 +885,10 @@ def apply_and_add_mutes(all_data, output_path, mute_check, aggregated_for_mute, 
         logging.error(f"Error processing test data: {e}. Check your query results for valid keys.")
         return []
 
-    return len(to_mute)
+    return {
+        'to_mute_count': len(to_mute),
+        'to_unmute': to_unmute,
+    }
 
 
 
@@ -899,15 +1083,66 @@ def mute_worker(args):
         # Use unified aggregation for different periods.
         aggregated_for_mute = aggregate_test_data(all_data, MUTE_DAYS)  # MUTE_DAYS for mute
         aggregated_for_unmute = aggregate_test_data(all_data, UNMUTE_DAYS)  # UNMUTE_DAYS for unmute
+        aggregated_for_fast_unmute = aggregate_test_data(all_data, FAST_UNMUTE_DAYS)
         aggregated_for_delete = aggregate_test_data(all_data, DELETE_DAYS)  # DELETE_DAYS for delete
     
-        logging.info(f"Aggregated data: mute={len(aggregated_for_mute)}, unmute={len(aggregated_for_unmute)}, delete={len(aggregated_for_delete)}")
+        logging.info(
+            "Aggregated data: "
+            f"mute={len(aggregated_for_mute)}, "
+            f"unmute={len(aggregated_for_unmute)}, "
+            f"fast_unmute={len(aggregated_for_fast_unmute)}, "
+            f"delete={len(aggregated_for_delete)}"
+        )
     
         if args.mode == 'update_muted_ya':
             output_path = args.output_folder
             os.makedirs(output_path, exist_ok=True)
             logging.info(f"Creating mute files in: {output_path}")
-            apply_and_add_mutes(all_data, output_path, mute_check, aggregated_for_mute, aggregated_for_unmute, aggregated_for_delete)
+            overrides_table_path = ydb_wrapper.get_table_path(UNMUTE_OVERRIDES_TABLE_NAME)
+            create_unmute_overrides_table(ydb_wrapper, overrides_table_path)
+
+            synced_count = sync_fast_unmute_overrides(
+                ydb_wrapper, overrides_table_path, args.branch, 'relwithdebinfo'
+            )
+            if synced_count:
+                logging.info(f"Synced {synced_count} fast-unmute override rows")
+
+            active_overrides = load_active_unmute_overrides(
+                ydb_wrapper, overrides_table_path, args.branch, 'relwithdebinfo'
+            )
+            logging.info(f"Loaded {len(active_overrides)} active fast-unmute overrides")
+
+            result = apply_and_add_mutes(
+                all_data,
+                output_path,
+                mute_check,
+                aggregated_for_mute,
+                aggregated_for_unmute,
+                aggregated_for_delete,
+                aggregated_for_fast_unmute=aggregated_for_fast_unmute,
+                fast_override_days_by_test=active_overrides,
+            )
+            if not isinstance(result, dict):
+                result = {}
+
+            consumed = set()
+            for mute_line in result.get('to_unmute', []):
+                parts = mute_line.split(' ', 1)
+                if len(parts) != 2:
+                    continue
+                full_name = f"{parts[0]}/{parts[1]}"
+                if full_name in active_overrides:
+                    consumed.add(full_name)
+
+            consumed_count = consume_unmute_overrides(
+                ydb_wrapper,
+                overrides_table_path,
+                args.branch,
+                'relwithdebinfo',
+                consumed,
+            )
+            if consumed_count:
+                logging.info(f"Consumed {consumed_count} fast-unmute overrides")
 
         elif args.mode == 'create_issues':
             file_path = args.file_path

--- a/.github/scripts/tests/update_mute_issues.py
+++ b/.github/scripts/tests/update_mute_issues.py
@@ -3,6 +3,7 @@ import sys
 import requests
 from github import Github #pip3 install PyGithub
 from urllib.parse import quote_plus
+import re
 
 # Import shared GitHub issue utilities
 sys.path.append(os.path.join(os.path.dirname(__file__), '..'))
@@ -24,6 +25,9 @@ CURRENT_TEST_HISTORY_DASHBOARD = "https://datalens.yandex/34xnbsom67hcq?"
 # project
 
 GITHUB_MAX_BODY_LENGTH = 65000  # Setting slightly below 65536 to be safe
+FAST_UNMUTE_LABEL = "fast-unmute-1d"
+UNMUTE_LIST_START_MARKER = "<!--unmute_list_start-->"
+UNMUTE_LIST_END_MARKER = "<!--unmute_list_end-->"
 
 def truncate_issue_body(body):
     """Truncates issue body if it exceeds GitHub's maximum length.
@@ -62,7 +66,9 @@ def handle_github_errors(response):
                 raise Exception("GraphQL Error: " + error.get('message', 'Unknown error'))
 
 def run_query(query, variables=None):
-    GITHUB_TOKEN = os.environ["GITHUB_TOKEN"]
+    GITHUB_TOKEN = os.environ.get("GITHUB_TOKEN") or os.environ.get("GH_TOKEN")
+    if not GITHUB_TOKEN:
+        raise Exception("Neither GITHUB_TOKEN nor GH_TOKEN is set")
     HEADERS = {"Authorization": f"Bearer {GITHUB_TOKEN}", "Content-Type": "application/json"}
     request = requests.post(
         'https://api.github.com/graphql', json={'query': query, 'variables': variables}, headers=HEADERS
@@ -267,6 +273,7 @@ def fetch_all_issues(org_name=ORG_NAME, project_id=PROJECT_ID):
               content {
                 ... on Issue {
                   id
+                  number
                   title
                   url
                   state
@@ -341,6 +348,43 @@ def fetch_all_issues(org_name=ORG_NAME, project_id=PROJECT_ID):
             has_next_page = False
 
     return issues
+
+
+def _extract_issue_number(issue_url):
+    if not issue_url:
+        return None
+    match = re.search(r"/issues/(\d+)$", issue_url)
+    return int(match.group(1)) if match else None
+
+
+def _extract_unmuted_tests_from_comment(comment_body):
+    if not comment_body:
+        return set()
+
+    if UNMUTE_LIST_START_MARKER in comment_body and UNMUTE_LIST_END_MARKER in comment_body:
+        start_idx = comment_body.find(UNMUTE_LIST_START_MARKER) + len(UNMUTE_LIST_START_MARKER)
+        end_idx = comment_body.find(UNMUTE_LIST_END_MARKER)
+        payload = comment_body[start_idx:end_idx]
+    else:
+        # Backward-compatible fallback for legacy comments without markers.
+        payload = comment_body
+
+    tests = set()
+    for line in payload.split('\n'):
+        line = line.strip()
+        if line.startswith('- Test '):
+            tests.add(line[len('- Test '):].replace(' unmuted', ''))
+    return tests
+
+
+def _build_unmute_comment(header, tests):
+    tests_payload = "\n".join(f"- Test {test}" for test in sorted(tests))
+    return (
+        f"{header}\n"
+        f"{UNMUTE_LIST_START_MARKER}\n"
+        f"{tests_payload}\n"
+        f"{UNMUTE_LIST_END_MARKER}"
+    )
 
 
 def generate_github_issue_title_and_body(test_data):
@@ -704,16 +748,18 @@ def has_unmute_comment(comments, unmuted_tests):
     test_set = set(unmuted_tests)
     for comment in comments:
         if "tests have been unmuted" in comment:
-            # Extract test names from the comment
-            comment_tests = set()
-            for line in comment.split('\n'):
-                if line.startswith('- Test '):
-                    test_name = line[7:]  # Remove '- Test ' prefix
-                    comment_tests.add(test_name.replace(' unmuted', ''))
+            comment_tests = _extract_unmuted_tests_from_comment(comment)
             # If all current unmuted tests are in the comment, we don't need a new one
             if test_set.issubset(comment_tests):
                 return True
     return False
+
+
+def _collect_issue_unmuted_tests(issue_id):
+    unmuted = set()
+    for comment in get_issue_comments(issue_id):
+        unmuted.update(_extract_unmuted_tests_from_comment(comment))
+    return unmuted
 
 def close_unmuted_issues(muted_tests_set, do_not_close_issues=False):
     """Closes issues where all tests are no longer muted.
@@ -769,7 +815,7 @@ def close_unmuted_issues(muted_tests_set, do_not_close_issues=False):
                 if len(unmuted_tests) == len(issue_info['tests']):
                     # Полностью размьючен
                     if not has_unmute_comment(existing_comments, unmuted_tests):
-                        comment = "All tests have been unmuted:\n" + "\n".join(f"- Test {test}" for test in sorted(unmuted_tests))
+                        comment = _build_unmute_comment("All tests have been unmuted:", unmuted_tests)
                         add_issue_comment(issue_id, comment)
                         if not do_not_close_issues:
                             close_issue(issue_id)
@@ -783,7 +829,7 @@ def close_unmuted_issues(muted_tests_set, do_not_close_issues=False):
                 elif 0 < len(unmuted_tests) < len(issue_info['tests']):
                     # Частично размьючен
                     if not has_unmute_comment(existing_comments, unmuted_tests):
-                        comment = "Some tests have been unmuted:\n" + "\n".join(f"- Test {test}" for test in sorted(unmuted_tests))
+                        comment = _build_unmute_comment("Some tests have been unmuted:", unmuted_tests)
                         add_issue_comment(issue_id, comment)
                         print(f"Added comment about unmuted tests to issue: {issue_info['url']}")
                         still_muted_tests = [test for test in issue_info['tests'] if test in muted_tests_set]
@@ -801,13 +847,67 @@ def close_unmuted_issues(muted_tests_set, do_not_close_issues=False):
     return closed_issues, partially_unmuted_issues
 
 
+def collect_fast_unmute_overrides(branch='main', build_type='relwithdebinfo', label_name=FAST_UNMUTE_LABEL):
+    """Collect per-test fast-unmute overrides from closed issues with explicit label.
+
+    For each closed issue with `label_name`, compute:
+      T_remaining_before_close = T_all (from issue body) - T_prev_unmuted (from comment markers)
+
+    Only tests in `T_remaining_before_close` are returned as override candidates.
+    """
+    overrides = []
+    issues = fetch_all_issues(ORG_NAME, PROJECT_ID)
+
+    for issue in issues:
+        content = issue.get('content')
+        if not content or content.get('state') != 'CLOSED':
+            continue
+
+        issue_labels = set()
+        for field_value in issue.get('fieldValues', {}).get('nodes', []):
+            labels = field_value.get('labels', {}).get('nodes', [])
+            for label in labels:
+                name = label.get('name')
+                if name:
+                    issue_labels.add(name)
+
+        if label_name not in issue_labels:
+            continue
+
+        parsed = parse_body(content.get('body', ''))
+        tests = parsed[0] if isinstance(parsed, tuple) else []
+        branches = parsed[1] if isinstance(parsed, tuple) else ['main']
+        if branch not in branches:
+            continue
+
+        all_tests = set(tests)
+        previously_unmuted = _collect_issue_unmuted_tests(content['id'])
+        remaining_tests = sorted(all_tests - previously_unmuted)
+        if not remaining_tests:
+            continue
+
+        issue_number = content.get('number') or _extract_issue_number(content.get('url'))
+        for test_name in remaining_tests:
+            overrides.append(
+                {
+                    'full_name': test_name,
+                    'branch': branch,
+                    'build_type': build_type,
+                    'window_days': 1,
+                    'reason': 'issue_fast_unmute_1d',
+                    'issue_number': issue_number,
+                }
+            )
+
+    return overrides
+
+
 def main():
 
-    if "GITHUB_TOKEN" not in os.environ:
-        print("Error: Env variable GITHUB_TOKEN is missing, skipping")
+    if "GITHUB_TOKEN" not in os.environ and "GH_TOKEN" not in os.environ:
+        print("Error: Env variable GITHUB_TOKEN or GH_TOKEN is missing, skipping")
         return 1
-    else:
-        github_token = os.environ["GITHUB_TOKEN"]
+    return 0
 
 if __name__ == "__main__":
     main()

--- a/.github/scripts/tests/update_mute_issues.py
+++ b/.github/scripts/tests/update_mute_issues.py
@@ -28,6 +28,11 @@ GITHUB_MAX_BODY_LENGTH = 65000  # Setting slightly below 65536 to be safe
 FAST_UNMUTE_LABEL = "fast-unmute-1d"
 UNMUTE_LIST_START_MARKER = "<!--unmute_list_start-->"
 UNMUTE_LIST_END_MARKER = "<!--unmute_list_end-->"
+KNOWN_BOT_LOGINS = {
+    "ydbot",
+    "github-actions[bot]",
+    "dependabot[bot]",
+}
 
 def truncate_issue_body(body):
     """Truncates issue body if it exceeds GitHub's maximum length.
@@ -279,6 +284,22 @@ def fetch_all_issues(org_name=ORG_NAME, project_id=PROJECT_ID):
                   state
                   body
                   createdAt
+                  closedAt
+                  timelineItems(last: 1, itemTypes: [CLOSED_EVENT]) {
+                    nodes {
+                      ... on ClosedEvent {
+                        actor {
+                          __typename
+                          ... on User {
+                            login
+                          }
+                          ... on Bot {
+                            login
+                          }
+                        }
+                      }
+                    }
+                  }
                 }
               }
               fieldValues(first: 20) {
@@ -355,6 +376,25 @@ def _extract_issue_number(issue_url):
         return None
     match = re.search(r"/issues/(\d+)$", issue_url)
     return int(match.group(1)) if match else None
+
+
+def _extract_close_actor(content):
+    timeline_nodes = (content or {}).get('timelineItems', {}).get('nodes', [])
+    if not timeline_nodes:
+        return None, None
+    actor = timeline_nodes[0].get('actor') or {}
+    return actor.get('login'), actor.get('__typename')
+
+
+def _is_bot_actor(login, actor_type):
+    if actor_type == "Bot":
+        return True
+    if not login:
+        return True
+    login_l = login.lower()
+    if login_l in KNOWN_BOT_LOGINS:
+        return True
+    return login_l.endswith("[bot]")
 
 
 def _extract_unmuted_tests_from_comment(comment_body):
@@ -847,7 +887,12 @@ def close_unmuted_issues(muted_tests_set, do_not_close_issues=False):
     return closed_issues, partially_unmuted_issues
 
 
-def collect_fast_unmute_overrides(branch='main', build_type='relwithdebinfo', label_name=FAST_UNMUTE_LABEL):
+def collect_fast_unmute_overrides(
+    branch='main',
+    build_type='relwithdebinfo',
+    label_name=FAST_UNMUTE_LABEL,
+    require_non_bot_close_actor=True,
+):
     """Collect per-test fast-unmute overrides from closed issues with explicit label.
 
     For each closed issue with `label_name`, compute:
@@ -857,8 +902,15 @@ def collect_fast_unmute_overrides(branch='main', build_type='relwithdebinfo', la
     """
     overrides = []
     issues = fetch_all_issues(ORG_NAME, PROJECT_ID)
+    stats = {
+        'issues_total': 0,
+        'issues_with_label': 0,
+        'issues_with_non_bot_close': 0,
+        'overrides_total': 0,
+    }
 
     for issue in issues:
+        stats['issues_total'] += 1
         content = issue.get('content')
         if not content or content.get('state') != 'CLOSED':
             continue
@@ -873,6 +925,12 @@ def collect_fast_unmute_overrides(branch='main', build_type='relwithdebinfo', la
 
         if label_name not in issue_labels:
             continue
+        stats['issues_with_label'] += 1
+
+        close_actor_login, close_actor_type = _extract_close_actor(content)
+        if require_non_bot_close_actor and _is_bot_actor(close_actor_login, close_actor_type):
+            continue
+        stats['issues_with_non_bot_close'] += 1
 
         parsed = parse_body(content.get('body', ''))
         tests = parsed[0] if isinstance(parsed, tuple) else []
@@ -898,7 +956,15 @@ def collect_fast_unmute_overrides(branch='main', build_type='relwithdebinfo', la
                     'issue_number': issue_number,
                 }
             )
+            stats['overrides_total'] += 1
 
+    print(
+        "FAST_UNMUTE_OVERRIDE_COLLECT: "
+        f"issues_total={stats['issues_total']}, "
+        f"issues_with_label={stats['issues_with_label']}, "
+        f"issues_with_non_bot_close={stats['issues_with_non_bot_close']}, "
+        f"overrides_total={stats['overrides_total']}"
+    )
     return overrides
 
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Add MVP infrastructure for opt-in fast unmute (1-day window) with safe gating and observability.

### Changelog category <!-- remove all except one -->

* Improvement

### Description for reviewers <!-- (optional) description for those who read this PR -->

This PR contains design + implementation for fast-unmute overrides while keeping default 7-day unmute behavior unchanged.

#### Implemented

1. **Marker-based unmute comments** (`update_mute_issues.py`)
   - Added machine-readable markers in comments:
     - `<!--unmute_list_start-->`
     - `<!--unmute_list_end-->`
   - Added backward-compatible parser for legacy comments.

2. **Fast-unmute override collection with non-bot gating** (`update_mute_issues.py`)
   - Added `collect_fast_unmute_overrides(...)` for closed issues with label `fast-unmute-1d`.
   - Applies to remaining tests only: `T_all - T_prev_unmuted`.
   - Added close-actor extraction from `ClosedEvent` timeline.
   - Added non-bot guard (Bot actor type, known bot logins, `[bot]` suffix).

3. **Override persistence and runtime use** (`create_new_muted_ya.py`)
   - Added `unmute_overrides` table lifecycle:
     - create table
     - upsert overrides
     - load active overrides
     - consume on successful unmute
   - Added per-test fast unmute window (1 day) only for active override rows.
   - Tests without override continue to use default 7-day logic.

4. **Hit-rate observability** (`create_new_muted_ya.py`)
   - Added metrics log:
     - active overrides
     - observed overrides in current data window
     - consumed overrides
     - hit_rate%
   - Added collection stats log in override collector.

5. **Config update**
   - Added table mapping in `.github/config/ydb_qa_config.json`:
     - `"unmute_overrides": "test_results/analytics/unmute_overrides"`

6. **Design docs**
   - Added `.github/config/fast_unmute_override_design.md`
   - Linked from `.github/config/mute_rules.md`

#### Validation

- `python3 -m py_compile .github/scripts/tests/update_mute_issues.py .github/scripts/tests/create_new_muted_ya.py`
- `python3 -m json.tool .github/config/ydb_qa_config.json`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8e69c739-3cae-49b0-86d8-d163a362363f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8e69c739-3cae-49b0-86d8-d163a362363f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

