### PR TITLE
Use control comments for manual fast-unmute with 24h gate

### DIFF
--- a/.github/config/mute_rules.md
+++ b/.github/config/mute_rules.md
@@ -15,7 +15,7 @@
 - If a user marks a test with `[x]`, status becomes `pending_24h`.
 - The request becomes eligible only after full 24 hours from `requested_at`.
 - After cooldown, fast rule applies: in last 1 day runs >= 4 and fail+mute = 0.
-- On success, bot keeps a historical strikethrough entry with reason (`stable_1d_manual`, `stable_7d`, `no_runs_7d`).
+- On success, bot keeps a historical strikethrough entry with reason (`stable_manual_fast_window`, `stable_default_window`, `no_runs_default_window`).
 
 ### Remove from mute if in the last 7 days:
 - **No runs at all** (pass + fail + mute + skip = 0)

--- a/.github/config/mute_rules.md
+++ b/.github/config/mute_rules.md
@@ -65,6 +65,12 @@ The `.github/workflows/create_issues_for_muted_tests.yml` workflow:
 - Get confirmation from the test owner.
 - After merging, move the issue to Unmuted status, link the PR and issue.
 
+### Fast unmute (1-day window) for manually fixed tests
+
+- Attach at least one related PR in the issue **Development** section.
+- Close the mute issue manually (not by bot).
+- Fast-unmute is activated automatically from this signal; no dedicated label is required.
+
 ## 📊 Dashboard for analyzing muted and flaky tests
 
 For analyzing test status, finding mute/unmute candidates, and tracking stability, use the interactive dashboard:

--- a/.github/config/mute_rules.md
+++ b/.github/config/mute_rules.md
@@ -10,6 +10,13 @@
 - **Runs (pass + fail + mute) >= 4**
 - **AND no failures (fail + mute = 0)**
 
+### Manual fast-unmute request (1-day window):
+- Bot maintains one or more issue comments with checkbox lists (`mute_control_v1`).
+- If a user marks a test with `[x]`, status becomes `pending_24h`.
+- The request becomes eligible only after full 24 hours from `requested_at`.
+- After cooldown, fast rule applies: in last 1 day runs >= 4 and fail+mute = 0.
+- On success, bot keeps a historical strikethrough entry with reason (`stable_1d_manual`, `stable_7d`, `no_runs_7d`).
+
 ### Remove from mute if in the last 7 days:
 - **No runs at all** (pass + fail + mute + skip = 0)
 

--- a/.github/scripts/tests/create_new_muted_ya.py
+++ b/.github/scripts/tests/create_new_muted_ya.py
@@ -18,6 +18,7 @@ from update_mute_issues import (
     generate_github_issue_title_and_body,
     get_muted_tests_from_issues,
     close_unmuted_issues,
+    collect_fast_unmute_overrides,
 )
 
 # Add analytics directory to path for ydb_wrapper import
@@ -35,6 +36,7 @@ muted_ya_path = '.github/config/muted_ya.txt'
 MUTE_DAYS = 4
 UNMUTE_DAYS = 7
 DELETE_DAYS = 7
+FAST_UNMUTE_DAYS = 1
 
 def is_chunk_test(test):
     # First, check the is_test_chunk field if it exists.
@@ -373,34 +375,45 @@ def is_mute_candidate(test, aggregated_data):
     
     return result
 
-def is_unmute_candidate(test, aggregated_data):
-    """Check whether a test is an unmute candidate for the given period."""
-    # Find this test in aggregated data.
-    test_data = None
-    for agg_test in aggregated_data:
-        if agg_test['full_name'] == test.get('full_name'):
-            test_data = agg_test
-            break
-    
+def is_unmute_candidate(test, aggregated_data, fast_aggregated_data=None, fast_override_days_by_test=None):
+    """Check whether a test is an unmute candidate, with optional per-test fast override."""
+    full_name = test.get('full_name')
+    fast_override_days_by_test = fast_override_days_by_test or {}
+    use_fast_window = full_name in fast_override_days_by_test and fast_aggregated_data is not None
+
+    source = fast_aggregated_data if use_fast_window else aggregated_data
+    if isinstance(source, dict):
+        test_data = source.get(full_name)
+    else:
+        test_data = None
+        for agg_test in source:
+            if agg_test['full_name'] == full_name:
+                test_data = agg_test
+                break
+
     if not test_data:
         return False
-    
+
     # Update test fields used by debug output.
     test['pass_count'] = test_data['pass_count']
     test['fail_count'] = test_data['fail_count']
     test['mute_count'] = test_data['mute_count']
     test['period_days'] = test_data.get('period_days')
     test['is_muted'] = test_data.get('is_muted', False)
-    
+
     total_runs = test_data['pass_count'] + test_data['fail_count'] + test_data['mute_count']
     total_fails = test_data['fail_count'] + test_data['mute_count']
-    
+
     result = total_runs >= 4 and total_fails == 0
-    
-    # Add detailed logging for diagnostics.
-    if test_data.get('is_muted', False):  # Log only for currently muted tests.
-        logging.debug(f"UNMUTE_CHECK: {test.get('full_name')} - runs:{total_runs}, fails:{total_fails}, mute_count:{test_data['mute_count']}, state:{test_data.get('state')}, muted:{test_data.get('is_muted')}, result:{result}")
-    
+
+    if test_data.get('is_muted', False):
+        mode = "FAST" if use_fast_window else "DEFAULT"
+        logging.debug(
+            f"UNMUTE_CHECK[{mode}]: {full_name} - runs:{total_runs}, fails:{total_fails}, "
+            f"mute_count:{test_data['mute_count']}, state:{test_data.get('state')}, "
+            f"muted:{test_data.get('is_muted')}, result:{result}"
+        )
+
     return result
 
 def is_delete_candidate(test, aggregated_data):
@@ -511,7 +524,16 @@ def write_file_set(file_path, test_set, debug_list=None, sort_without_prefixes=F
         add_lines_to_file(debug_path, [line + '\n' for line in sorted_debug_list])
     logging.info(f"Created {os.path.basename(file_path)} with {len(sorted_test_set)} tests")
 
-def apply_and_add_mutes(all_data, output_path, mute_check, aggregated_for_mute, aggregated_for_unmute, aggregated_for_delete):
+def apply_and_add_mutes(
+    all_data,
+    output_path,
+    mute_check,
+    aggregated_for_mute,
+    aggregated_for_unmute,
+    aggregated_for_delete,
+    aggregated_for_fast_unmute=None,
+    fast_override_days_by_test=None,
+):
     output_path = os.path.join(output_path, 'mute_update')
     logging.info(f"Creating mute files in directory: {output_path}")
     
@@ -533,10 +555,20 @@ def apply_and_add_mutes(all_data, output_path, mute_check, aggregated_for_mute, 
         write_file_set(os.path.join(output_path, 'to_mute.txt'), to_mute, to_mute_debug)
         
         # 2. Unmute candidates.
+        fast_override_days_by_test = fast_override_days_by_test or {}
+        aggregated_for_fast_unmute_index = {
+            test['full_name']: test for test in (aggregated_for_fast_unmute or [])
+        }
+
         def is_unmute_candidate_wrapper(test):
             if is_chunk_test(test):
                 return False  # Do not unmute chunks individually.
-            return is_unmute_candidate(test, aggregated_for_unmute)
+            return is_unmute_candidate(
+                test,
+                aggregated_for_unmute,
+                fast_aggregated_data=aggregated_for_fast_unmute_index,
+                fast_override_days_by_test=fast_override_days_by_test,
+            )
         
         # Regular unmute candidates (non-chunk tests only).
         to_unmute, to_unmute_debug = create_file_set(
@@ -546,7 +578,16 @@ def apply_and_add_mutes(all_data, output_path, mute_check, aggregated_for_mute, 
         # Wildcard unmute patterns:
         # If all pattern chunks pass the filter, unmute the whole pattern.
         # If at least one chunk fails, the pattern is not unmuted.
-        wildcard_unmute = get_wildcard_unmute_candidates(aggregated_for_unmute, mute_check, is_unmute_candidate)
+        wildcard_unmute = get_wildcard_unmute_candidates(
+            aggregated_for_unmute,
+            mute_check,
+            lambda test, _: is_unmute_candidate(
+                test,
+                aggregated_for_unmute,
+                fast_aggregated_data=aggregated_for_fast_unmute_index,
+                fast_override_days_by_test=fast_override_days_by_test,
+            ),
+        )
         wildcard_unmute_patterns = [p for p, d in wildcard_unmute]
         wildcard_unmute_debugs = [d for p, d in wildcard_unmute]
         
@@ -704,7 +745,10 @@ def apply_and_add_mutes(all_data, output_path, mute_check, aggregated_for_mute, 
         logging.error(f"Error processing test data: {e}. Check your query results for valid keys.")
         return []
 
-    return len(to_mute)
+    return {
+        'to_mute_count': len(to_mute),
+        'to_unmute': to_unmute,
+    }
 
 
 
@@ -881,6 +925,8 @@ def mute_worker(args):
 
         logging.info(f"Starting mute worker with mode: {args.mode}")
         logging.info(f"Branch: {args.branch}")
+        build_type = getattr(args, 'build_type', 'relwithdebinfo')
+        logging.info(f"Build type: {build_type}")
         
         # Use provided muted_ya file or fallback to default.
         input_muted_ya_path = getattr(args, 'muted_ya_file', muted_ya_path)
@@ -893,21 +939,52 @@ def mute_worker(args):
         logging.info("Executing single query for 7 days window...")
         
         # Single query for maximum window (7 days).
-        all_data = execute_query(args.branch, days_window=7)
+        all_data = execute_query(args.branch, build_type=build_type, days_window=7)
         logging.info(f"Query returned {len(all_data)} test records")
         
         # Use unified aggregation for different periods.
         aggregated_for_mute = aggregate_test_data(all_data, MUTE_DAYS)  # MUTE_DAYS for mute
         aggregated_for_unmute = aggregate_test_data(all_data, UNMUTE_DAYS)  # UNMUTE_DAYS for unmute
+        aggregated_for_fast_unmute = aggregate_test_data(all_data, FAST_UNMUTE_DAYS)
         aggregated_for_delete = aggregate_test_data(all_data, DELETE_DAYS)  # DELETE_DAYS for delete
     
-        logging.info(f"Aggregated data: mute={len(aggregated_for_mute)}, unmute={len(aggregated_for_unmute)}, delete={len(aggregated_for_delete)}")
+        logging.info(
+            "Aggregated data: "
+            f"mute={len(aggregated_for_mute)}, "
+            f"unmute={len(aggregated_for_unmute)}, "
+            f"fast_unmute={len(aggregated_for_fast_unmute)}, "
+            f"delete={len(aggregated_for_delete)}"
+        )
     
         if args.mode == 'update_muted_ya':
             output_path = args.output_folder
             os.makedirs(output_path, exist_ok=True)
             logging.info(f"Creating mute files in: {output_path}")
-            apply_and_add_mutes(all_data, output_path, mute_check, aggregated_for_mute, aggregated_for_unmute, aggregated_for_delete)
+
+            overrides = collect_fast_unmute_overrides(
+                branch=args.branch,
+                build_type=build_type,
+            )
+            fast_override_days_by_test = {
+                item['full_name']: int(item.get('window_days', FAST_UNMUTE_DAYS))
+                for item in overrides
+                if item.get('full_name')
+            }
+            logging.info(
+                "FAST_UNMUTE_OVERRIDES: "
+                f"raw_rows={len(overrides)}, unique_tests={len(fast_override_days_by_test)}"
+            )
+
+            apply_and_add_mutes(
+                all_data,
+                output_path,
+                mute_check,
+                aggregated_for_mute,
+                aggregated_for_unmute,
+                aggregated_for_delete,
+                aggregated_for_fast_unmute=aggregated_for_fast_unmute,
+                fast_override_days_by_test=fast_override_days_by_test,
+            )
 
         elif args.mode == 'create_issues':
             file_path = args.file_path
@@ -927,6 +1004,7 @@ if __name__ == "__main__":
     update_muted_ya_parser = subparsers.add_parser('update_muted_ya', help='create new muted_ya')
     update_muted_ya_parser.add_argument('--output_folder', default=repo_path, required=False, help='Output folder.')
     update_muted_ya_parser.add_argument('--branch', default='main', help='Branch to get history')
+    update_muted_ya_parser.add_argument('--build_type', default='relwithdebinfo', help='Build type for monitor query')
     update_muted_ya_parser.add_argument('--muted_ya_file', default=muted_ya_path, help='Path to input muted_ya.txt file')
 
     create_issues_parser = subparsers.add_parser(
@@ -937,6 +1015,7 @@ if __name__ == "__main__":
         '--file_path', default=f'{repo_path}/mute_update/to_mute.txt', required=False, help='file path'
     )
     create_issues_parser.add_argument('--branch', default='main', help='Branch to get history')
+    create_issues_parser.add_argument('--build_type', default='relwithdebinfo', help='Build type for monitor query')
     create_issues_parser.add_argument('--close_issues', action='store_true', default=True, help='Close issues when all tests are unmuted (default: True)')
 
     args = parser.parse_args()

--- a/.github/scripts/tests/create_new_muted_ya.py
+++ b/.github/scripts/tests/create_new_muted_ya.py
@@ -961,9 +961,23 @@ def mute_worker(args):
             os.makedirs(output_path, exist_ok=True)
             logging.info(f"Creating mute files in: {output_path}")
 
+            stable_unmute_candidates = {
+                test.get('full_name')
+                for test in aggregated_for_unmute
+                if test.get('full_name') and is_unmute_candidate(test, aggregated_for_unmute)
+            }
+            stable_delete_candidates = {
+                test.get('full_name')
+                for test in aggregated_for_delete
+                if test.get('full_name') and is_delete_candidate(test, aggregated_for_delete)
+            }
+
             overrides = collect_fast_unmute_overrides(
                 branch=args.branch,
                 build_type=build_type,
+                stable_unmute_candidates=stable_unmute_candidates,
+                delete_candidates=stable_delete_candidates,
+                require_linked_development_pr=False,
             )
             fast_override_days_by_test = {
                 item['full_name']: int(item.get('window_days', FAST_UNMUTE_DAYS))

--- a/.github/scripts/tests/update_mute_issues.py
+++ b/.github/scripts/tests/update_mute_issues.py
@@ -24,6 +24,14 @@ CURRENT_TEST_HISTORY_DASHBOARD = "https://datalens.yandex/34xnbsom67hcq?"
 # project
 
 GITHUB_MAX_BODY_LENGTH = 65000  # Setting slightly below 65536 to be safe
+FAST_UNMUTE_AUTO_COMMENT_MARKER = "<!--fast-unmute-auto:v1-->"
+UNMUTE_LIST_START_MARKER = "<!--unmute_list_start-->"
+UNMUTE_LIST_END_MARKER = "<!--unmute_list_end-->"
+KNOWN_BOT_LOGINS = {
+    "ydbot",
+    "github-actions[bot]",
+    "dependabot[bot]",
+}
 
 def truncate_issue_body(body):
     """Truncates issue body if it exceeds GitHub's maximum length.
@@ -62,7 +70,9 @@ def handle_github_errors(response):
                 raise Exception("GraphQL Error: " + error.get('message', 'Unknown error'))
 
 def run_query(query, variables=None):
-    GITHUB_TOKEN = os.environ["GITHUB_TOKEN"]
+    GITHUB_TOKEN = os.environ.get("GITHUB_TOKEN") or os.environ.get("GH_TOKEN")
+    if not GITHUB_TOKEN:
+        raise Exception("Neither GITHUB_TOKEN nor GH_TOKEN is set")
     HEADERS = {"Authorization": f"Bearer {GITHUB_TOKEN}", "Content-Type": "application/json"}
     request = requests.post(
         'https://api.github.com/graphql', json={'query': query, 'variables': variables}, headers=HEADERS
@@ -267,11 +277,60 @@ def fetch_all_issues(org_name=ORG_NAME, project_id=PROJECT_ID):
               content {
                 ... on Issue {
                   id
+                  number
                   title
                   url
                   state
                   body
                   createdAt
+                  closedAt
+                  timelineItems(
+                    last: 50,
+                    itemTypes: [CLOSED_EVENT, CONNECTED_EVENT, CROSS_REFERENCED_EVENT]
+                  ) {
+                    nodes {
+                      __typename
+                      ... on ClosedEvent {
+                        actor {
+                          __typename
+                          ... on User {
+                            login
+                          }
+                          ... on Bot {
+                            login
+                          }
+                        }
+                      }
+                      ... on ConnectedEvent {
+                        subject {
+                          __typename
+                          ... on PullRequest {
+                            number
+                            url
+                            state
+                            isDraft
+                            repository {
+                              nameWithOwner
+                            }
+                          }
+                        }
+                      }
+                      ... on CrossReferencedEvent {
+                        source {
+                          __typename
+                          ... on PullRequest {
+                            number
+                            url
+                            state
+                            isDraft
+                            repository {
+                              nameWithOwner
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
                 }
               }
               fieldValues(first: 20) {
@@ -343,6 +402,220 @@ def fetch_all_issues(org_name=ORG_NAME, project_id=PROJECT_ID):
     return issues
 
 
+def _extract_close_actor(content):
+    timeline_nodes = (content or {}).get('timelineItems', {}).get('nodes', [])
+    for node in reversed(timeline_nodes):
+        if node.get('__typename') != 'ClosedEvent':
+            continue
+        actor = node.get('actor') or {}
+        return actor.get('login'), actor.get('__typename')
+    return None, None
+
+
+def _is_bot_actor(login, actor_type):
+    if actor_type == 'Bot':
+        return True
+    if not login:
+        return True
+    login_l = login.lower()
+    if login_l in KNOWN_BOT_LOGINS:
+        return True
+    return login_l.endswith('[bot]')
+
+
+def _extract_unmuted_tests_from_comment(comment_body):
+    if not comment_body:
+        return set()
+
+    if UNMUTE_LIST_START_MARKER in comment_body and UNMUTE_LIST_END_MARKER in comment_body:
+        start_idx = comment_body.find(UNMUTE_LIST_START_MARKER) + len(UNMUTE_LIST_START_MARKER)
+        end_idx = comment_body.find(UNMUTE_LIST_END_MARKER)
+        payload = comment_body[start_idx:end_idx]
+    else:
+        # Backward-compatible fallback for legacy comments without markers.
+        payload = comment_body
+
+    tests = set()
+    for line in payload.split('\n'):
+        line = line.strip()
+        if line.startswith('- Test '):
+            tests.add(line[len('- Test '):].replace(' unmuted', ''))
+    return tests
+
+
+def _collect_issue_unmuted_tests(issue_id):
+    unmuted = set()
+    for comment in get_issue_comments(issue_id):
+        unmuted.update(_extract_unmuted_tests_from_comment(comment))
+    return unmuted
+
+
+def _build_unmute_comment(header, tests):
+    tests_payload = "\n".join(f"- Test {test}" for test in sorted(tests))
+    return (
+        f"{header}\n"
+        f"{UNMUTE_LIST_START_MARKER}\n"
+        f"{tests_payload}\n"
+        f"{UNMUTE_LIST_END_MARKER}"
+    )
+
+
+def _extract_linked_development_pull_requests(content):
+    timeline_nodes = (content or {}).get('timelineItems', {}).get('nodes', [])
+    repo_full_name = f"{ORG_NAME}/{REPO_NAME}".lower()
+    linked_prs = {}
+
+    for node in timeline_nodes:
+        pr = None
+        if node.get('__typename') == 'ConnectedEvent':
+            subject = node.get('subject') or {}
+            if subject.get('__typename') == 'PullRequest':
+                pr = subject
+        elif node.get('__typename') == 'CrossReferencedEvent':
+            source = node.get('source') or {}
+            if source.get('__typename') == 'PullRequest':
+                pr = source
+
+        if not pr:
+            continue
+
+        pr_repo = ((pr.get('repository') or {}).get('nameWithOwner') or '').lower()
+        if pr_repo and pr_repo != repo_full_name:
+            continue
+
+        if pr.get('isDraft'):
+            continue
+
+        if pr.get('state') not in {'OPEN', 'MERGED'}:
+            continue
+
+        number = pr.get('number')
+        if number is None:
+            continue
+        linked_prs[number] = pr
+
+    return [linked_prs[number] for number in sorted(linked_prs)]
+
+
+def _has_fast_unmute_comment(comments):
+    return any(FAST_UNMUTE_AUTO_COMMENT_MARKER in (comment or '') for comment in comments)
+
+
+def _build_fast_unmute_comment(issue_number, closer_login, linked_prs):
+    linked_pr_lines = "\n".join(
+        f"- #{pr.get('number')} ({pr.get('state')}): {pr.get('url')}" for pr in linked_prs
+    )
+    return (
+        f"{FAST_UNMUTE_AUTO_COMMENT_MARKER}\n"
+        f"Fast-unmute flow enabled for issue #{issue_number}.\n\n"
+        "Reason:\n"
+        f"- issue was closed manually by @{closer_login}\n"
+        "- linked PR found in Development context\n\n"
+        "Linked PRs:\n"
+        f"{linked_pr_lines}\n\n"
+        "Result:\n"
+        "- tests from this issue become eligible for 1-day unmute window in mute update flow"
+    )
+
+
+def collect_fast_unmute_overrides(
+    branch='main',
+    build_type='relwithdebinfo',
+    require_non_bot_close_actor=True,
+    require_linked_development_pr=True,
+    add_auto_comment=True,
+):
+    """Collect fast-unmute overrides from closed mute issues.
+
+    Fast path is enabled for an issue only when:
+      - issue is closed manually by a non-bot actor
+      - issue has linked pull request(s) in Development context
+
+    For each eligible issue:
+      T_remaining_before_close = T_all (from issue body) - T_prev_unmuted (from issue comments)
+    """
+    overrides = []
+    issues = fetch_all_issues(ORG_NAME, PROJECT_ID)
+    stats = {
+        'issues_total': 0,
+        'issues_closed': 0,
+        'issues_non_bot_closed': 0,
+        'issues_with_linked_pr': 0,
+        'issues_branch_match': 0,
+        'overrides_total': 0,
+    }
+
+    for issue in issues:
+        stats['issues_total'] += 1
+        content = issue.get('content') or {}
+        if content.get('state') != 'CLOSED':
+            continue
+        stats['issues_closed'] += 1
+
+        body = content.get('body', '')
+        if '<!--mute_list_start-->' not in body or '<!--mute_list_end-->' not in body:
+            continue
+
+        close_actor_login, close_actor_type = _extract_close_actor(content)
+        if require_non_bot_close_actor and _is_bot_actor(close_actor_login, close_actor_type):
+            continue
+        stats['issues_non_bot_closed'] += 1
+
+        linked_prs = _extract_linked_development_pull_requests(content)
+        if require_linked_development_pr and not linked_prs:
+            continue
+        stats['issues_with_linked_pr'] += 1
+
+        tests, branches = parse_body(body)
+        if branch not in branches:
+            continue
+        stats['issues_branch_match'] += 1
+
+        issue_id = content.get('id')
+        if not issue_id:
+            continue
+        all_tests = set(tests)
+        previously_unmuted = _collect_issue_unmuted_tests(issue_id)
+        remaining_tests = sorted(all_tests - previously_unmuted)
+        if not remaining_tests:
+            continue
+
+        issue_number = content.get('number')
+        for test_name in remaining_tests:
+            overrides.append(
+                {
+                    'full_name': test_name,
+                    'branch': branch,
+                    'build_type': build_type,
+                    'window_days': 1,
+                    'reason': 'issue_closed_by_human_with_linked_pr',
+                    'issue_number': issue_number,
+                }
+            )
+            stats['overrides_total'] += 1
+
+        if add_auto_comment and issue_id and linked_prs:
+            comments = get_issue_comments(issue_id)
+            if not _has_fast_unmute_comment(comments):
+                comment = _build_fast_unmute_comment(
+                    issue_number=issue_number,
+                    closer_login=close_actor_login or 'unknown',
+                    linked_prs=linked_prs,
+                )
+                add_issue_comment(issue_id, comment)
+
+    print(
+        "FAST_UNMUTE_OVERRIDE_COLLECT: "
+        f"issues_total={stats['issues_total']}, "
+        f"issues_closed={stats['issues_closed']}, "
+        f"issues_non_bot_closed={stats['issues_non_bot_closed']}, "
+        f"issues_with_linked_pr={stats['issues_with_linked_pr']}, "
+        f"issues_branch_match={stats['issues_branch_match']}, "
+        f"overrides_total={stats['overrides_total']}"
+    )
+    return overrides
+
+
 def generate_github_issue_title_and_body(test_data):
     owner = test_data[0]['owner']
     branch = test_data[0]['branch']
@@ -389,6 +662,10 @@ def generate_github_issue_title_and_body(test_data):
         f"{test_mute_strings_string}\n"
         "```\n\n"
         f"Owner: {owner}\n\n"
+        "**Fast unmute (1-day window):**\n"
+        "- After the fix, attach at least one related PR in this issue's **Development** section.\n"
+        "- Close this issue manually (by human, not bot).\n"
+        "- Fast-unmute flow is auto-enabled from close actor + linked PR signal (no manual label required).\n\n"
         "**Read more in [mute_rules.md](https://github.com/ydb-platform/ydb/blob/main/.github/config/mute_rules.md)**\n\n"
         f"**Summary history:** \n {summary_string}\n"
         "\n\n"
@@ -704,12 +981,7 @@ def has_unmute_comment(comments, unmuted_tests):
     test_set = set(unmuted_tests)
     for comment in comments:
         if "tests have been unmuted" in comment:
-            # Extract test names from the comment
-            comment_tests = set()
-            for line in comment.split('\n'):
-                if line.startswith('- Test '):
-                    test_name = line[7:]  # Remove '- Test ' prefix
-                    comment_tests.add(test_name.replace(' unmuted', ''))
+            comment_tests = _extract_unmuted_tests_from_comment(comment)
             # If all current unmuted tests are in the comment, we don't need a new one
             if test_set.issubset(comment_tests):
                 return True
@@ -769,7 +1041,7 @@ def close_unmuted_issues(muted_tests_set, do_not_close_issues=False):
                 if len(unmuted_tests) == len(issue_info['tests']):
                     # Полностью размьючен
                     if not has_unmute_comment(existing_comments, unmuted_tests):
-                        comment = "All tests have been unmuted:\n" + "\n".join(f"- Test {test}" for test in sorted(unmuted_tests))
+                        comment = _build_unmute_comment("All tests have been unmuted:", unmuted_tests)
                         add_issue_comment(issue_id, comment)
                         if not do_not_close_issues:
                             close_issue(issue_id)
@@ -783,7 +1055,7 @@ def close_unmuted_issues(muted_tests_set, do_not_close_issues=False):
                 elif 0 < len(unmuted_tests) < len(issue_info['tests']):
                     # Частично размьючен
                     if not has_unmute_comment(existing_comments, unmuted_tests):
-                        comment = "Some tests have been unmuted:\n" + "\n".join(f"- Test {test}" for test in sorted(unmuted_tests))
+                        comment = _build_unmute_comment("Some tests have been unmuted:", unmuted_tests)
                         add_issue_comment(issue_id, comment)
                         print(f"Added comment about unmuted tests to issue: {issue_info['url']}")
                         still_muted_tests = [test for test in issue_info['tests'] if test in muted_tests_set]
@@ -803,11 +1075,10 @@ def close_unmuted_issues(muted_tests_set, do_not_close_issues=False):
 
 def main():
 
-    if "GITHUB_TOKEN" not in os.environ:
-        print("Error: Env variable GITHUB_TOKEN is missing, skipping")
+    if "GITHUB_TOKEN" not in os.environ and "GH_TOKEN" not in os.environ:
+        print("Error: Env variable GITHUB_TOKEN or GH_TOKEN is missing, skipping")
         return 1
-    else:
-        github_token = os.environ["GITHUB_TOKEN"]
+    return 0
 
 if __name__ == "__main__":
     main()

--- a/.github/scripts/tests/update_mute_issues.py
+++ b/.github/scripts/tests/update_mute_issues.py
@@ -33,6 +33,9 @@ UNMUTE_LIST_END_MARKER = "<!--unmute_list_end-->"
 MUTE_CONTROL_MARKER = "<!--mute_control_v1-->"
 MUTE_CONTROL_PART_MAX_TESTS = 200
 MANUAL_FAST_UNMUTE_WAIT_HOURS = 24
+REASON_NO_RUNS_DEFAULT_WINDOW = "no_runs_default_window"
+REASON_STABLE_MANUAL_FAST_WINDOW = "stable_manual_fast_window"
+REASON_STABLE_DEFAULT_WINDOW = "stable_default_window"
 KNOWN_BOT_LOGINS = {
     "ydbot",
     "github-actions[bot]",
@@ -582,7 +585,7 @@ def _render_control_comment(issue_number, part_idx, part_total, items):
         check = "x" if requested and state == 'active' else " "
 
         if state == 'resolved':
-            reason_text = reason or 'stable_7d'
+            reason_text = reason or REASON_STABLE_DEFAULT_WINDOW
             meta = f"state:resolved reason:{reason_text}"
             if resolved_at:
                 meta += f" resolved_at:{resolved_at}"
@@ -709,10 +712,10 @@ def _build_pending_status_comment(issue_number, new_requests):
 
 def _derive_resolution_reason(test_name, had_manual_request, stable_unmute_candidates, delete_candidates):
     if test_name in delete_candidates:
-        return 'no_runs_7d'
+        return REASON_NO_RUNS_DEFAULT_WINDOW
     if test_name in stable_unmute_candidates:
-        return 'stable_1d_manual' if had_manual_request else 'stable_7d'
-    return 'stable_7d'
+        return REASON_STABLE_MANUAL_FAST_WINDOW if had_manual_request else REASON_STABLE_DEFAULT_WINDOW
+    return REASON_STABLE_DEFAULT_WINDOW
 
 
 def collect_fast_unmute_overrides(

--- a/.github/scripts/tests/update_mute_issues.py
+++ b/.github/scripts/tests/update_mute_issues.py
@@ -3,6 +3,8 @@ import sys
 import requests
 from github import Github #pip3 install PyGithub
 from urllib.parse import quote_plus
+import datetime
+import re
 
 # Import shared GitHub issue utilities
 sys.path.append(os.path.join(os.path.dirname(__file__), '..'))
@@ -25,8 +27,12 @@ CURRENT_TEST_HISTORY_DASHBOARD = "https://datalens.yandex/34xnbsom67hcq?"
 
 GITHUB_MAX_BODY_LENGTH = 65000  # Setting slightly below 65536 to be safe
 FAST_UNMUTE_AUTO_COMMENT_MARKER = "<!--fast-unmute-auto:v1-->"
+FAST_UNMUTE_PENDING_COMMENT_MARKER = "<!--fast-unmute-pending:v1-->"
 UNMUTE_LIST_START_MARKER = "<!--unmute_list_start-->"
 UNMUTE_LIST_END_MARKER = "<!--unmute_list_end-->"
+MUTE_CONTROL_MARKER = "<!--mute_control_v1-->"
+MUTE_CONTROL_PART_MAX_TESTS = 200
+MANUAL_FAST_UNMUTE_WAIT_HOURS = 24
 KNOWN_BOT_LOGINS = {
     "ydbot",
     "github-actions[bot]",
@@ -518,6 +524,197 @@ def _build_fast_unmute_comment(issue_number, closer_login, linked_prs):
     )
 
 
+def _utc_now():
+    return datetime.datetime.now(datetime.timezone.utc)
+
+
+def _parse_iso8601(value):
+    if not value:
+        return None
+    normalized = value.replace('Z', '+00:00')
+    try:
+        dt = datetime.datetime.fromisoformat(normalized)
+    except ValueError:
+        return None
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=datetime.timezone.utc)
+    return dt.astimezone(datetime.timezone.utc)
+
+
+def _isoformat_z(dt_value):
+    return dt_value.astimezone(datetime.timezone.utc).replace(microsecond=0).isoformat().replace('+00:00', 'Z')
+
+
+def _split_tests_into_chunks(test_names):
+    names = sorted(set(test_names))
+    if not names:
+        return [[]]
+    return [names[i:i + MUTE_CONTROL_PART_MAX_TESTS] for i in range(0, len(names), MUTE_CONTROL_PART_MAX_TESTS)]
+
+
+def _control_part_start(part_idx, part_total):
+    return f"{MUTE_CONTROL_MARKER}:start part:{part_idx}/{part_total}"
+
+
+def _control_part_end():
+    return f"{MUTE_CONTROL_MARKER}:end"
+
+
+def _render_control_comment(issue_number, part_idx, part_total, items):
+    lines = [
+        _control_part_start(part_idx, part_total),
+        "### Mute control list (managed by bot)",
+        f"Issue #{issue_number} | part {part_idx}/{part_total}",
+        "",
+        "Mark `[x]` on active lines to request manual fast-unmute.",
+        f"Fast-unmute starts after full {MANUAL_FAST_UNMUTE_WAIT_HOURS}h from `requested_at`.",
+        "",
+    ]
+
+    for test_name in sorted(items):
+        item = items[test_name]
+        requested = bool(item.get('requested'))
+        state = item.get('state', 'active')
+        requested_at = item.get('requested_at')
+        status = item.get('status') or 'idle'
+        reason = item.get('reason')
+        resolved_at = item.get('resolved_at')
+        check = "x" if requested and state == 'active' else " "
+
+        if state == 'resolved':
+            reason_text = reason or 'stable_7d'
+            meta = f"state:resolved reason:{reason_text}"
+            if resolved_at:
+                meta += f" resolved_at:{resolved_at}"
+            lines.append(
+                f"- [{check}] ~~`{test_name}`~~ - unmuted: {reason_text} <!--{meta}-->"
+            )
+            continue
+
+        meta_parts = [f"state:active", f"status:{status}"]
+        if requested_at:
+            meta_parts.append(f"requested_at:{requested_at}")
+        meta = " ".join(meta_parts)
+        lines.append(f"- [{'x' if requested else ' '}] `{test_name}` <!--{meta}-->")
+
+    lines.extend(
+        [
+            "",
+            "Legend:",
+            "- active + [x] => manual fast-unmute requested",
+            "- pending_24h => waiting cooldown",
+            "- ready_for_fast_unmute => eligible for 1-day stability check",
+            "- strikethrough => historical (already unmuted/removed)",
+            _control_part_end(),
+        ]
+    )
+    return "\n".join(lines)
+
+
+def _parse_control_items(comment_body):
+    if not comment_body or MUTE_CONTROL_MARKER not in comment_body:
+        return {}
+    start_idx = comment_body.find(f"{MUTE_CONTROL_MARKER}:start")
+    end_idx = comment_body.find(f"{MUTE_CONTROL_MARKER}:end", start_idx if start_idx >= 0 else 0)
+    if start_idx < 0 or end_idx < 0:
+        return {}
+    payload = comment_body[start_idx:end_idx]
+    items = {}
+    for raw in payload.split('\n'):
+        line = raw.strip()
+        if not line.startswith('- ['):
+            continue
+        m = re.search(r'`([^`]+)`', line)
+        if not m:
+            continue
+        test_name = m.group(1).strip()
+        requested = line.startswith('- [x]') or line.startswith('- [X]')
+        state_match = re.search(r'state:([a-z_]+)', line)
+        status_match = re.search(r'status:([a-z0-9_]+)', line)
+        reason_match = re.search(r'reason:([a-z0-9_]+)', line)
+        requested_at_match = re.search(r'requested_at:([0-9T:\-+Z]+)', line)
+        resolved_at_match = re.search(r'resolved_at:([0-9T:\-+Z]+)', line)
+        items[test_name] = {
+            'requested': requested,
+            'state': state_match.group(1) if state_match else 'active',
+            'status': status_match.group(1) if status_match else ('pending_24h' if requested else 'idle'),
+            'reason': reason_match.group(1) if reason_match else '',
+            'requested_at': requested_at_match.group(1) if requested_at_match else '',
+            'resolved_at': resolved_at_match.group(1) if resolved_at_match else '',
+        }
+    return items
+
+
+def get_issue_comments_with_ids(issue_id):
+    query = """
+    {
+      node(id: "%s") {
+        ... on Issue {
+          comments(first: 100) {
+            nodes {
+              id
+              body
+            }
+          }
+        }
+      }
+    }
+    """ % issue_id
+    result = run_query(query)
+    nodes = result.get('data', {}).get('node', {}).get('comments', {}).get('nodes', [])
+    return [{'id': node.get('id'), 'body': node.get('body', '')} for node in nodes if node.get('id')]
+
+
+def edit_issue_comment(comment_id, comment):
+    query = """
+    mutation ($commentId: ID!, $body: String!) {
+      updateIssueComment(input: {id: $commentId, body: $body}) {
+        issueComment {
+          id
+        }
+      }
+    }
+    """
+    variables = {"commentId": comment_id, "body": comment}
+    result = run_query(query, variables)
+    if not result.get('errors'):
+        print(f"Updated comment {comment_id}")
+    else:
+        print(f"Error: Failed to update comment {comment_id}")
+
+
+def _list_control_comments(issue_id):
+    comments = get_issue_comments_with_ids(issue_id)
+    return [comment for comment in comments if f"{MUTE_CONTROL_MARKER}:start" in (comment.get('body') or '')]
+
+
+def _build_pending_status_comment(issue_number, new_requests):
+    lines = []
+    for test_name, requested_at in sorted(new_requests):
+        requested_dt = _parse_iso8601(requested_at)
+        if requested_dt:
+            eta = _isoformat_z(requested_dt + datetime.timedelta(hours=MANUAL_FAST_UNMUTE_WAIT_HOURS))
+        else:
+            eta = f"in {MANUAL_FAST_UNMUTE_WAIT_HOURS}h"
+        lines.append(f"- `{test_name}` => pending_24h, eligible at `{eta}`")
+    return (
+        f"{FAST_UNMUTE_PENDING_COMMENT_MARKER}\n"
+        f"Manual fast-unmute request registered for issue #{issue_number}.\n\n"
+        "Selected tests:\n"
+        f"{chr(10).join(lines)}\n\n"
+        f"Rule: full {MANUAL_FAST_UNMUTE_WAIT_HOURS}h cooldown + stable 1-day window "
+        "(>=4 runs, 0 fail/mute)."
+    )
+
+
+def _derive_resolution_reason(test_name, had_manual_request, stable_unmute_candidates, delete_candidates):
+    if test_name in delete_candidates:
+        return 'no_runs_7d'
+    if test_name in stable_unmute_candidates:
+        return 'stable_1d_manual' if had_manual_request else 'stable_7d'
+    return 'stable_7d'
+
+
 def collect_fast_unmute_overrides(
     branch='main',
     build_type='relwithdebinfo',
@@ -525,14 +722,14 @@ def collect_fast_unmute_overrides(
     require_linked_development_pr=True,
     add_auto_comment=True,
 ):
-    """Collect fast-unmute overrides from closed mute issues.
+    """Collect fast-unmute overrides from mute issues using control comments.
 
-    Fast path is enabled for an issue only when:
-      - issue is closed manually by a non-bot actor
-      - issue has linked pull request(s) in Development context
-
-    For each eligible issue:
-      T_remaining_before_close = T_all (from issue body) - T_prev_unmuted (from issue comments)
+    Behavior:
+      - create/update bot-managed control comments with checkbox rows;
+      - when user marks [x], row becomes pending_24h and gets requested_at;
+      - row is eligible for fast-unmute only after full 24h cooldown;
+      - for manually closed issues by human, all active rows are auto-requested.
+      - once a test is no longer muted, row is struck through with reason.
     """
     overrides = []
     issues = fetch_all_issues(ORG_NAME, PROJECT_ID)
@@ -543,28 +740,22 @@ def collect_fast_unmute_overrides(
         'issues_with_linked_pr': 0,
         'issues_branch_match': 0,
         'overrides_total': 0,
+        'pending_24h': 0,
+        'new_requests': 0,
     }
+
+    now = _utc_now()
 
     for issue in issues:
         stats['issues_total'] += 1
         content = issue.get('content') or {}
-        if content.get('state') != 'CLOSED':
+        state = content.get('state')
+        if state not in {'OPEN', 'CLOSED'}:
             continue
-        stats['issues_closed'] += 1
 
         body = content.get('body', '')
         if '<!--mute_list_start-->' not in body or '<!--mute_list_end-->' not in body:
             continue
-
-        close_actor_login, close_actor_type = _extract_close_actor(content)
-        if require_non_bot_close_actor and _is_bot_actor(close_actor_login, close_actor_type):
-            continue
-        stats['issues_non_bot_closed'] += 1
-
-        linked_prs = _extract_linked_development_pull_requests(content)
-        if require_linked_development_pr and not linked_prs:
-            continue
-        stats['issues_with_linked_pr'] += 1
 
         tests, branches = parse_body(body)
         if branch not in branches:
@@ -574,27 +765,140 @@ def collect_fast_unmute_overrides(
         issue_id = content.get('id')
         if not issue_id:
             continue
-        all_tests = set(tests)
+        issue_number = content.get('number')
+
         previously_unmuted = _collect_issue_unmuted_tests(issue_id)
-        remaining_tests = sorted(all_tests - previously_unmuted)
+        remaining_tests = sorted(set(tests) - previously_unmuted)
         if not remaining_tests:
             continue
 
-        issue_number = content.get('number')
-        for test_name in remaining_tests:
-            overrides.append(
-                {
-                    'full_name': test_name,
-                    'branch': branch,
-                    'build_type': build_type,
-                    'window_days': 1,
-                    'reason': 'issue_closed_by_human_with_linked_pr',
-                    'issue_number': issue_number,
-                }
-            )
-            stats['overrides_total'] += 1
+        linked_prs = _extract_linked_development_pull_requests(content)
+        is_closed = state == 'CLOSED'
+        close_actor_login, close_actor_type = _extract_close_actor(content)
+        closed_by_human = is_closed and not _is_bot_actor(close_actor_login, close_actor_type)
 
-        if add_auto_comment and issue_id and linked_prs:
+        if is_closed:
+            stats['issues_closed'] += 1
+            if require_non_bot_close_actor and not closed_by_human:
+                continue
+            if closed_by_human:
+                stats['issues_non_bot_closed'] += 1
+
+            if require_linked_development_pr and not linked_prs:
+                continue
+
+        if linked_prs:
+            stats['issues_with_linked_pr'] += 1
+
+        existing_control_comments = _list_control_comments(issue_id)
+        control_items = {}
+        for comment in existing_control_comments:
+            control_items.update(_parse_control_items(comment.get('body', '')))
+        for test_name in remaining_tests:
+            control_items.setdefault(
+                test_name,
+                {
+                    'requested': False,
+                    'state': 'active',
+                    'status': 'idle',
+                    'reason': '',
+                    'requested_at': '',
+                    'resolved_at': '',
+                },
+            )
+
+        changed = False
+        new_requests = []
+
+        for test_name in remaining_tests:
+            item = control_items[test_name]
+            if item.get('state') == 'resolved':
+                continue
+
+            if closed_by_human and not item.get('requested'):
+                item['requested'] = True
+                changed = True
+
+            if item.get('requested'):
+                if not item.get('requested_at'):
+                    item['requested_at'] = _isoformat_z(now)
+                    new_requests.append((test_name, item['requested_at']))
+                    changed = True
+
+                requested_dt = _parse_iso8601(item.get('requested_at'))
+                if requested_dt is None:
+                    item['status'] = 'pending_24h'
+                    stats['pending_24h'] += 1
+                    continue
+
+                ready_dt = requested_dt + datetime.timedelta(hours=FAST_UNMUTE_WAIT_HOURS)
+                if now >= ready_dt:
+                    if item.get('status') != 'ready_for_fast_unmute':
+                        item['status'] = 'ready_for_fast_unmute'
+                        changed = True
+                    overrides.append(
+                        {
+                            'full_name': test_name,
+                            'branch': branch,
+                            'build_type': build_type,
+                            'window_days': 1,
+                            'reason': 'manual_unmute_after_24h',
+                            'issue_number': issue_number,
+                            'requested_at': item.get('requested_at'),
+                        }
+                    )
+                    stats['overrides_total'] += 1
+                else:
+                    if item.get('status') != 'pending_24h':
+                        item['status'] = 'pending_24h'
+                        changed = True
+                    stats['pending_24h'] += 1
+            else:
+                if item.get('status') != 'idle':
+                    item['status'] = 'idle'
+                    changed = True
+                if item.get('requested_at'):
+                    item['requested_at'] = ''
+                    changed = True
+
+        active_items = {name: control_items[name] for name in remaining_tests if control_items[name].get('state') != 'resolved'}
+        active_chunks = _split_tests_into_chunks(active_items.keys())
+        desired_parts = max(len(active_chunks), len(existing_control_comments), 1)
+        rendered_parts = []
+        for idx in range(desired_parts):
+            part_tests = active_chunks[idx] if idx < len(active_chunks) else []
+            part_items = {name: active_items[name] for name in part_tests}
+            rendered_parts.append(
+                _render_control_comment(
+                    issue_number=issue_number,
+                    part_idx=idx + 1,
+                    part_total=desired_parts,
+                    items=part_items,
+                )
+            )
+
+        existing_sorted = sorted(existing_control_comments, key=lambda x: x.get('id', ''))
+        for idx, rendered in enumerate(rendered_parts):
+            if idx < len(existing_sorted):
+                old_body = existing_sorted[idx].get('body', '')
+                if old_body != rendered:
+                    edit_issue_comment(existing_sorted[idx]['id'], rendered)
+            else:
+                add_issue_comment(issue_id, rendered)
+
+        if new_requests:
+            stats['new_requests'] += len(new_requests)
+            add_issue_comment(issue_id, _build_pending_status_comment(issue_number, new_requests))
+        elif is_closed and closed_by_human:
+            ready_now = [
+                name
+                for name in remaining_tests
+                if (control_items.get(name) or {}).get('status') == 'ready_for_fast_unmute'
+            ]
+            if ready_now:
+                add_issue_comment(issue_id, _build_pending_status_comment(issue_number, [(name, (control_items.get(name) or {}).get('requested_at')) for name in ready_now]))
+
+        if add_auto_comment and is_closed and linked_prs:
             comments = get_issue_comments(issue_id)
             if not _has_fast_unmute_comment(comments):
                 comment = _build_fast_unmute_comment(
@@ -611,6 +915,8 @@ def collect_fast_unmute_overrides(
         f"issues_non_bot_closed={stats['issues_non_bot_closed']}, "
         f"issues_with_linked_pr={stats['issues_with_linked_pr']}, "
         f"issues_branch_match={stats['issues_branch_match']}, "
+        f"pending_24h={stats['pending_24h']}, "
+        f"new_requests={stats['new_requests']}, "
         f"overrides_total={stats['overrides_total']}"
     )
     return overrides
@@ -663,9 +969,10 @@ def generate_github_issue_title_and_body(test_data):
         "```\n\n"
         f"Owner: {owner}\n\n"
         "**Fast unmute (1-day window):**\n"
-        "- After the fix, attach at least one related PR in this issue's **Development** section.\n"
-        "- Close this issue manually (by human, not bot).\n"
-        "- Fast-unmute flow is auto-enabled from close actor + linked PR signal (no manual label required).\n\n"
+        "- Bot maintains control comments with checkbox list for muted tests.\n"
+        "- Mark `[x]` near a test to request manual fast-unmute for this test.\n"
+        f"- Request enters `pending_24h`; fast-unmute starts only after full {MANUAL_FAST_UNMUTE_WAIT_HOURS}h cooldown.\n"
+        "- If issue is closed manually (by human), all remaining active tests are auto-requested.\n\n"
         "**Read more in [mute_rules.md](https://github.com/ydb-platform/ydb/blob/main/.github/config/mute_rules.md)**\n\n"
         f"**Summary history:** \n {summary_string}\n"
         "\n\n"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

...

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

Implements manual fast-unmute UX using bot-managed control comments with checkboxes and strict 24h cooldown.

What changed:
- Added control-comment model in `.github/scripts/tests/update_mute_issues.py`:
  - Bot creates/updates comment parts with test checklist rows.
  - Supports large issues by splitting across multiple comments (part N/K).
  - Rows track machine metadata (`state`, `status`, `requested_at`, `reason`) in HTML comment tags.
- Manual request flow:
  - User marks `[x]` on active test row.
  - Bot stamps `requested_at` and marks status `pending_24h`.
  - Bot posts status comment for newly requested tests (ETA shown).
- Fast-unmute eligibility:
  - Test becomes eligible only after full 24h from `requested_at`.
  - Then it is emitted as 1-day override candidate (`manual_unmute_after_24h`).
- Closed issue behavior:
  - For issue closed by human, all active tests are auto-requested.
  - We disabled strict linked-PR requirement in collector call for this stage (`require_linked_development_pr=False`) to match requested UX.
- Control-comment history:
  - When CI observes test already unmuted/removed, row is rendered as strikethrough with window-agnostic reason codes (`stable_manual_fast_window`, `stable_default_window`, `no_runs_default_window`).
- Updated issue body guidance + `mute_rules.md` with new control-comment and `pending_24h` semantics.

Validation:
- `python3 -m py_compile .github/scripts/tests/update_mute_issues.py .github/scripts/tests/create_new_muted_ya.py`
- Runtime smoke execution is dependency-bound in this environment (`PyGithub`, `ydb` not installed).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2f3e0017-464a-40d8-b452-63fd5a5ce668"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2f3e0017-464a-40d8-b452-63fd5a5ce668"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

