### PR TITLE
Simplify user-fixed mute quarantine flow

### DIFF
--- a/.github/config/mute_coordinator_thresholds.json
+++ b/.github/config/mute_coordinator_thresholds.json
@@ -1,0 +1,12 @@
+{
+  "default_mute_window_days": 4,
+  "default_unmute_window_days": 7,
+  "default_delete_window_days": 7,
+  "default_unmute_min_runs": 4,
+  "default_mute_total_runs_branch_boundary": 10,
+  "default_mute_min_fails_high_volume": 3,
+  "default_mute_min_fails_low_volume": 2,
+  "default_mute_min_fails_medium_volume": 2,
+  "default_mute_medium_volume_total_runs_gt_exclusive": 10,
+  "quarantine_user_fixed_window_days": 7
+}

--- a/.github/config/mute_rules.md
+++ b/.github/config/mute_rules.md
@@ -1,101 +1,101 @@
-# 📖 Простые правила mute / unmute
+# Mute / Unmute rules (short guide)
 
-Этот файл — короткая памятка для людей: **что произойдет с тестом и почему**.
-
----
-
-## 1) Когда тест замьютится (`to_mute`)
-
-Смотрим последние **4 дня**:
-
-- если запусков (`pass + fail`) **больше 10** — нужно минимум **3 fail**
-- если запусков **10 или меньше** — нужно минимум **2 fail**
-
-Пример:
-- 15 запусков, 3 fail → попадет в mute
-- 6 запусков, 2 fail → попадет в mute
+This is a short human-readable guide that explains when tests are muted or unmuted.
 
 ---
 
-## 2) Когда тест размьютится (`to_unmute`)
+## MUTE when (`to_mute`)
 
-Смотрим последние **7 дней**:
+Look at the last **4 days**:
 
-- запусков (`pass + fail + mute`) не меньше **4**
-- ошибок (`fail + mute`) ровно **0**
+- if runs (`pass + fail`) are **more than 10** -> need at least **3 fails**
+- if runs are **10 or less** -> need at least **2 fails**
 
-Пример:
-- 5 запусков, все успешные → попадет в unmute
-
----
-
-## 3) Когда тест удаляется из mute (`to_delete`)
-
-Смотрим последние **7 дней**:
-
-- либо запусков нет вообще
-- либо тест был muted и все события были только `skip`
+Examples:
+- 15 runs, 3 fails -> goes to mute
+- 6 runs, 2 fails -> goes to mute
 
 ---
 
-## 4) Карантин для user-fixed тестов
+## UNMUTE when (`to_unmute`)
 
-Если issue по тесту закрыт **пользователем** и с причиной закрытия `COMPLETED`, тест может попасть в карантин:
+Look at the last **7 days**:
 
-- `hide` — временно скрываем из итогового muted-файла
-- `stable` — карантин закончился, условия unmute выполнены, остается размьюченным
-- `restore` — карантин закончился, условия unmute не выполнены, возвращаем в muted
+- runs (`pass + fail + mute`) are at least **4**
+- failures (`fail + mute`) are exactly **0**
 
-Важно:
-- закрытия с `NOT_PLANNED` / `DUPLICATE` и т.п. **не считаются user-fixed**
-- если чтение issues временно недоступно, карантин безопасно отключается для этого прогона
+Example:
+- 5 runs, all successful -> goes to unmute
 
 ---
 
-## 5) Что обновляется автоматически
+## REMOVE FROM MUTE when (`to_delete`)
 
-### Workflow обновления mute
+Look at the last **7 days**:
+
+- either there were no runs at all
+- or the test was muted and only had `skip` events
+
+---
+
+## User-fixed quarantine
+
+If a test issue was closed by a **User** with `state_reason == COMPLETED`, the test can enter quarantine:
+
+- `hide` - temporarily hide from final muted output
+- `stable` - quarantine ended and unmute conditions still pass
+- `restore` - quarantine ended but unmute conditions do not pass, return to muted
+
+Important:
+- `NOT_PLANNED`, `DUPLICATE`, and other non-completed closure reasons are **not** treated as user-fixed
+- if issues data is unavailable, quarantine is safely disabled for that run
+
+---
+
+## What is updated automatically
+
+### Mute update workflow
 `.github/workflows/update_muted_ya.yml`
 
-- запускается по расписанию (каждый час с 04:00 до 21:00 UTC) и вручную (`workflow_dispatch`)
-- считает кандидатов, строит `mute_update/new_muted_ya.txt`
-- если есть изменения, открывает/обновляет PR с `.github/config/muted_ya.txt`
+- runs on schedule (hourly from 04:00 to 21:00 UTC) and manually (`workflow_dispatch`)
+- calculates candidates and builds `mute_update/new_muted_ya.txt`
+- opens/updates PR with `.github/config/muted_ya.txt` if changes exist
 
-### Workflow создания issues
+### Issue sync workflow
 `.github/workflows/create_issues_for_muted_tests.yml`
 
-- срабатывает после merge PR в `main` (для PR с label `mute-unmute`) или вручную
-- создает/обновляет mute issues и обновляет аналитические таблицы
+- runs after merge to `main` (for PRs with `mute-unmute` label) or manually
+- creates/updates mute issues and refreshes analytics tables
 
 ---
 
-## 6) Главные выходные файлы (`mute_update/`)
+## Main output files (`mute_update/`)
 
-- `to_mute.txt` — что добавить в mute
-- `to_unmute.txt` — что убрать из mute как стабильное
-- `to_delete.txt` — что удалить из mute как неактуальное
-- `new_muted_ya.txt` — итоговый файл, который идет в `.github/config/muted_ya.txt`
-- `muted_ya_changes.txt` — изменения с префиксами:
-  - `+++` добавили в mute
-  - `---` убрали из mute
-  - `xxx` удалили как неактуальное
+- `to_mute.txt` - tests to add to mute
+- `to_unmute.txt` - tests to unmute as stable
+- `to_delete.txt` - tests to remove from mute as stale
+- `new_muted_ya.txt` - final file used to update `.github/config/muted_ya.txt`
+- `muted_ya_changes.txt` - change list with prefixes:
+  - `+++` added to mute
+  - `---` removed from mute
+  - `xxx` removed as stale
 
-Карантинные снапшоты:
+Quarantine snapshots:
 - `quarantine_hidden.txt`
 - `quarantine_restored.txt`
 - `quarantine_stable_unmuted.txt`
 
-Для большинства файлов есть `*_debug.txt` с объяснениями.
+Most files also have `*_debug.txt` with explanation details.
 
 ---
 
-## 7) Где менять пороги
+## Where to change thresholds
 
-- `.github/config/mute_coordinator_thresholds.json` — основные числа (окна, минимумы)
-- `.github/scripts/mute_policy_rules.py` — fallback-значения и предикаты
+- `.github/config/mute_coordinator_thresholds.json` - primary thresholds
+- `.github/scripts/mute_policy_rules.py` - fallback values and predicates
 
 ---
 
-## 8) Дашборд
+## Dashboard
 
 - https://datalens.yandex/4un3zdm0zcnyr

--- a/.github/config/mute_rules.md
+++ b/.github/config/mute_rules.md
@@ -1,259 +1,116 @@
-## 📖 Mute and Unmute Rules
+# Mute / Unmute automation runbook
 
----
+This document describes the **current** behavior of mute automation in this repository.
 
-### Mute a test if in the last 4 days:
-- **3 or more failures AND runs (pass + fail) more than 10**
-- **OR** 2 or more failures AND runs (pass + fail) not more than 10
+## Decision rules
 
-### Unmute a test if in the last 7 days:
-- **Runs (pass + fail + mute) >= 4**
-- **AND no failures (fail + mute = 0)**
+Rule thresholds are loaded from:
 
-### Remove from mute if in the last 7 days:
-- **No runs at all** (pass + fail + mute + skip = 0)
+- `.github/config/mute_coordinator_thresholds.json`
+- fallback defaults in `.github/scripts/mute_policy_rules.py`
 
----
+### Mute candidate
 
-### Notes
-- For all rules, only the last N days are considered (N=4 for mute, N=7 for unmute, N=7 for delete), including the current day.
-- A "run" is any test execution with result pass, fail, or mute.
-- A "failure" is a test execution with result fail or mute.
-- Statistics aggregation is done by key (test_name, suite_folder, full_name, build_type, branch).
+A test is added to `to_mute` when it is not currently muted and satisfies default mute predicate.
 
----
+Default threshold values:
 
-**Example:**
-- If a test ran 15 times in 3 days with 3 failures — the test will be muted.
-- If a test ran 5 times in 3 days with 2 failures — the test will be muted.
-- If a test ran 4 times in 7 days and all passed successfully — the test will be unmuted.
-- If a test didn't run at all in 7 days — it will be removed from mute.
+- window: `4` days
+- if `pass + fail > 10`, require at least `3` fails
+- otherwise require at least `2` fails
 
-## 🔄 Automated Workflow
+### Unmute candidate
 
-### Automatic muted_ya.txt Updates
-The `.github/workflows/update_muted_ya.yml` workflow automatically:
-- Runs every 2 hours from 6:00 to 20:00 UTC
-- Analyzes test data for the last 4-7 days
-- Creates a PR with updated `muted_ya.txt` based on the rules above
-- The PR should be approved to merge by CI Team @ydb-platform/ci
+A test is added to `to_unmute` when default unmute predicate passes.
 
-### Automatic Issue Creation
-The `.github/workflows/create_issues_for_muted_tests.yml` workflow:
-- Triggers after approval of PRs with `mute-unmute` label
-- Creates GitHub issues for newly muted tests and close unmute
-- Assigns issues to appropriate teams based on test ownership
-- Links issues to the PR that introduced the mutes
+Default threshold values:
 
-## 📝 Manual mute/unmute management
+- window: `7` days
+- minimum runs `(pass + fail + mute) >= 4`
+- failures `(fail + mute) == 0`
 
-### How to mute a test manually
+### Delete-from-mute candidate (`to_delete`)
 
-- Open [muted_ya.txt](https://github.com/ydb-platform/ydb/blob/main/.github/config/muted_ya.txt) and add a test line.
-- Create a PR, copy the title and description from the issue.
-- Get confirmation from the test owner.
-- After merging, link the PR and issue, notify the team.
+A muted test is added to `to_delete` when:
 
-**You can also:**
-- Use the context menu in the PR report (see screenshot).
-- Use [Test history dashboard](https://datalens.yandex/4un3zdm0zcnyr?tab=A4) to search and mute a test.
+- it has no runs in the delete window, or
+- it was muted and only skipped in the window.
 
-### How to unmute a test manually
+Default delete window: `7` days.
 
-- Open [muted_ya.txt](https://github.com/ydb-platform/ydb/blob/main/.github/config/muted_ya.txt) and remove the test line.
-- Create a PR with title "UnMute {testname}".
-- Get confirmation from the test owner.
-- After merging, move the issue to Unmuted status, link the PR and issue.
+## User-fixed quarantine
 
-## 📊 Dashboard for analyzing muted and flaky tests
+Quarantine logic lives in `.github/scripts/tests/mute_quarantine.py`.
 
-For analyzing test status, finding mute/unmute candidates, and tracking stability, use the interactive dashboard:
+Signal source: recently closed issues from YDB `issues` table where:
 
-- [YDB Test Analytics Dashboard](https://datalens.yandex/4un3zdm0zcnyr)
+- `closed_by_type == "User"`
+- closure reason is `COMPLETED` (non-completed user closures are rejected)
+- issue body maps to current branch/build profile
 
-**Dashboard capabilities:**
-- View all muted tests by owner, full_name, status
-- Quick search by test name or team (owner)
-- Filter by status (flaky, muted, stable, etc.)
-- History of runs and failures by day
-- Tables of mute/unmute candidates (see corresponding tabs)
-- Quick transition to creating mute-issues via link in the table
+Actions:
 
-**Usage examples:**
-- Find all muted tests for your team: select owner in the filter
-- Find flaky candidates for mute: Flaky tab, filter by fail_count/run_count
-- Find stable mutes for unmute: Stable tab, filter by success_rate
+- `hide`: test is hidden from generated muted output while quarantine window is active
+- `stable`: quarantine ended and unmute rule is still satisfied
+- `restore`: quarantine ended, unmute rule is not satisfied -> return to muted output
 
-## 📋 Files generated by create_new_muted_ya.py
+Fail-safe behavior:
 
-### 🔇 [to_mute.txt](mute_update/to_mute.txt)
-**Content:** Mute candidates by new rules  
-**Rules:** In 4 days (≥3 failures **AND** runs >10) **OR** (≥2 failures **AND** runs ≤10)  
-**Usage:** Main file for mute decisions
+- if issues table path/query fails, quarantine returns empty actions with explicit error code in stats
 
-### 🔊 [to_unmute.txt](mute_update/to_unmute.txt)
-**Content:** Unmute candidates by new rules  
-**Rules:** In 7 days ≥4 runs (pass+fail+mute), no failures (fail+mute=0)  
-**Usage:** Main file for unmute decisions
+## Workflows
 
-### 🗑️ [to_remove_from_mute.txt](mute_update/to_remove_from_mute.txt)
-**Content:** Tests to remove from mute  
-**Rules:** No runs in 7 days  
-**Usage:** Main file for removal from mute
+### 1) Update muted file
 
-## 📊 Additional analysis files
+Workflow: `.github/workflows/update_muted_ya.yml`
 
-### 🔍 [muted_ya-deleted.txt](mute_update/muted_ya-deleted.txt)
-**Content:** Tests from muted_ya minus deleted tests  
-**Formula:** `muted_ya` - `deleted`  
-**Usage:** Analysis of active tests in mute
+- schedule: hourly, from `04:00` to `21:00` UTC
+- also supports `workflow_dispatch`
+- generates `mute_update/new_muted_ya.txt`
+- if changed vs base branch file, opens/updates PR with `.github/config/muted_ya.txt`
 
-### 🔍 [muted_ya-stable.txt](mute_update/muted_ya-stable.txt)
-**Content:** Tests from muted_ya minus stable tests  
-**Formula:** `muted_ya` - `stable`  
-**Usage:** Analysis of unstable tests in mute
+### 2) Create issues for merged mute PR
 
-### 🔍 [muted_ya-stable-deleted.txt](mute_update/muted_ya-stable-deleted.txt)
-**Content:** Tests from muted_ya minus stable and deleted  
-**Formula:** `muted_ya` - `stable` - `deleted`  
-**Usage:** Analysis of active unstable tests
+Workflow: `.github/workflows/create_issues_for_muted_tests.yml`
 
-### 🔍 [muted_ya-stable-deleted+flaky.txt](mute_update/muted_ya-stable-deleted+flaky.txt)
-**Content:** Tests from muted_ya minus stable and deleted, plus flaky  
-**Formula:** `muted_ya` - `stable` - `deleted` + `flaky`  
-**Usage:** Creating GitHub issues
+- triggers when PR to `main` is merged
+- runs only for PRs with label `mute-unmute`
+- also supports `workflow_dispatch`
+- creates missing mute issues, comments PR, refreshes analytics tables
 
-## 📋 Debug files (with details)
+## Generated files (`mute_update/`)
 
-### 🔍 [muted_ya-deleted_debug.txt](mute_update/muted_ya-deleted_debug.txt)
-**Content:** Details for tests muted_ya - deleted  
-**Additional:** owner, success_rate, state, days_in_state
+### Core action files
 
-### 🔍 [muted_ya-stable_debug.txt](mute_update/muted_ya-stable_debug.txt)
-**Content:** Details for tests muted_ya - stable  
-**Additional:** owner, success_rate, state, days_in_state
+| File | Meaning |
+|---|---|
+| `to_mute.txt` | Candidates to add into mute |
+| `to_unmute.txt` | Candidates to unmute |
+| `to_delete.txt` | Candidates to remove from mute because they disappeared / only skipped |
+| `muted_ya.txt` | Current muted set reconstructed from monitor rows |
+| `new_muted_ya.txt` | Final output used to update `.github/config/muted_ya.txt` |
 
-### 🔍 [muted_ya-stable-deleted_debug.txt](mute_update/muted_ya-stable-deleted_debug.txt)
-**Content:** Details for tests muted_ya - stable - deleted  
-**Additional:** owner, success_rate, state, days_in_state
+### Intermediate snapshots
 
-### 🔍 [muted_ya-stable-deleted+flaky_debug.txt](mute_update/muted_ya-stable-deleted+flaky_debug.txt)
-**Content:** Details for tests muted_ya - stable - deleted + flaky  
-**Additional:** owner, success_rate, state, days_in_state, pass_count, fail_count
+| File | Meaning |
+|---|---|
+| `muted_ya+to_mute.txt` | current muted + new mute candidates |
+| `muted_ya-to_unmute.txt` | current muted minus unmute candidates |
+| `muted_ya-to_delete.txt` | current muted minus delete candidates |
+| `muted_ya-to-delete-to-unmute.txt` | current muted minus delete and unmute |
+| `muted_ya-to-delete-to-unmute+to_mute.txt` | pre-final merged set before copying to `new_muted_ya.txt` |
+| `muted_ya_changes.txt` | combined diff-like view (`+++`, `---`, `xxx`) |
 
----
+### Quarantine snapshots
 
-## 🔄 File lifecycle
+| File | Meaning |
+|---|---|
+| `quarantine_hidden.txt` | hidden during quarantine |
+| `quarantine_restored.txt` | restored after failed quarantine |
+| `quarantine_stable_unmuted.txt` | stayed unmuted after quarantine |
 
-1. **Data analysis** → Creation of main action files
-2. **Rule application** → Formation of three main files
-3. **Additional analysis** → Creation of files for analyzing various combinations
-4. **Issue creation** → Using `new_muted_ya.txt`
+For most `.txt` files, a corresponding `*_debug.txt` file is generated with decision context.
 
-**All files are created in the `mute_update/` directory when running the script. The final mute file for workflow is `new_muted_ya.txt`.**
+## Dashboards
 
-# Mute logic output files table
-
-This table shows all files created by the mute logic script, with descriptions of their content and purpose.
-
-## 📋 Main files
-
-| File | Description | Rules | Usage |
-|------|----------|---------|---------------|
-| `to_mute.txt` | Mute candidates | In 4 days ≥2 failures **OR** (≥1 failure and runs ≤10) | Main file for mute decisions |
-| `to_unmute.txt` | Unmute candidates | In 7 days ≥4 runs (pass+fail+mute), no failures (fail+mute=0) | Main file for unmute decisions |
-| `to_remove_from_mute.txt` | Tests to remove from mute | No runs in 7 days | Main file for removal from mute |
-
-## 📊 Additional analysis files
-
-| File | Description | Formula | Usage |
-|------|----------|---------|---------------|
-| `muted_ya.txt` | All currently muted tests | aggregated over 4 days | Base for mute analysis |
-| `muted_ya+to_mute.txt` | muted_ya + to_mute | | Analysis of potential mutes |
-| `muted_ya-to_unmute.txt` | muted_ya - to_unmute | | Analysis of potential unmutes |
-| `muted_ya-to_delete.txt` | muted_ya - to_delete | | Analysis of potential deletions |
-| `muted_ya-to-delete-to-unmute.txt` | muted_ya - to_delete - to_unmute | | Analysis of active mutes |
-| `muted_ya-to-delete-to-unmute+to_mute.txt` | (muted_ya - to_delete - to_unmute) + to_mute | | For final mute file |
-| `new_muted_ya.txt` | Final mute file for workflow (duplicates muted_ya-to-delete-to-unmute+to_mute.txt) | copy of previous | Used for automatic update of .github/config/muted_ya.txt |
-
-## 📋 Debug files (with details)
-
-| File | Description | Additional information |
-|------|----------|---------------------------|
-| `muted_ya-deleted_debug.txt` | Details for tests muted_ya - deleted | owner, success_rate, state, days_in_state |
-| `muted_ya-stable_debug.txt` | Details for tests muted_ya - stable | owner, success_rate, state, days_in_state |
-| `muted_ya-stable-deleted_debug.txt` | Details for tests muted_ya - stable - deleted | owner, success_rate, state, days_in_state |
-| `muted_ya-stable-deleted+flaky_debug.txt` | Details for tests muted_ya - stable - deleted + flaky | owner, success_rate, state, days_in_state, pass_count, fail_count |
-
----
-## Muted Tests Workflow Diagram
-
-### Main Workflow: Update Muted YA → PR Merge → Notifications
-
-```mermaid
-graph TB
-    Start([Schedule: Every 2h<br/>or Manual]) --> UpdateAnalytics[📊 Update Analytics<br/>flaky_tests_history<br/>upload_muted_tests<br/>tests_monitor]
-    
-    UpdateAnalytics --> GenerateFile[📝 Generate new muted_ya.txt<br/>create_new_muted_ya.py]
-    
-    GenerateFile --> CheckChanges{Changes?}
-    CheckChanges -->|No| End1([End])
-    CheckChanges -->|Yes| CreatePR[📦 Create PR<br/>with changes]
-    
-    CreatePR --> CommentPR[💬 Comment PR<br/>Add labels & reviewers]
-    CommentPR --> AutoMerge[🔄 Enable auto-merge]
-    AutoMerge --> WaitMerge[⏳ Wait for PR merge]
-    
-    WaitMerge --> PRMerged[✅ PR Merged<br/>Trigger: create_issues_for_muted_tests.yml]
-    
-    PRMerged --> CreateIssues[📋 Create GitHub Issues<br/>for new muted tests]
-    CreateIssues --> CommentMergedPR[💬 Comment merged PR<br/>Add issues info]
-    
-    CommentMergedPR --> UpdateAnalyticsAfterMerge[📊 Update Analytics<br/>upload_muted_tests<br/>flaky_tests_history<br/>tests_monitor<br/>export_issues<br/>github_issue_mapping<br/>test_muted_monitor_mart]
-    
-    UpdateAnalyticsAfterMerge --> SendTelegram[📨 Send Telegram Messages<br/>with trend plots<br/>to team channels]
-    
-    SendTelegram --> End2([End])
-    
-    style Start fill:#e1f5ff
-    style UpdateAnalytics fill:#ffe1ff
-    style UpdateAnalyticsAfterMerge fill:#ffe1ff
-    style CommentPR fill:#fff4e1
-    style CommentMergedPR fill:#fff4e1
-    style SendTelegram fill:#e1ffe1
-    style End1 fill:#ffe1e1
-    style End2 fill:#e1ffe1
-    style CheckChanges fill:#fff4e1
-    style PRMerged fill:#e1e1ff
-```
-
-### Analytics Update Sequence
-
-```mermaid
-sequenceDiagram
-    participant W as Workflow
-    participant YDB as YDB Database
-    participant GH as GitHub
-    participant TG as Telegram
-    
-    Note over W: update_muted_ya.yml (Periodic)
-    W->>YDB: 1. flaky_tests_history.py<br/>Collect test history
-    W->>YDB: 2. upload_muted_tests<br/>Update muted status
-    W->>YDB: 3. tests_monitor.py<br/>Update monitoring
-    W->>W: Generate new muted_ya.txt
-    W->>GH: Create PR (if changes)
-    
-    Note over W: PR Merged → create_issues_for_muted_tests.yml
-    W->>GH: Create issues
-    W->>GH: Comment PR
-    
-    W->>YDB: 4. upload_muted_tests<br/>Update muted status
-    W->>YDB: 5. flaky_tests_history.py<br/>Collect test history
-    W->>YDB: 6. tests_monitor.py<br/>Update monitoring
-    W->>YDB: 7. export_issues_to_ydb.py<br/>Export GitHub issues
-    W->>YDB: 8. github_issue_mapping.py<br/>Create issue mapping
-    W->>YDB: 9. test_muted_monitor_mart<br/>Update data mart
-    
-    W->>TG: Send messages with plots
-```
-
+- Main test analytics dashboard: https://datalens.yandex/4un3zdm0zcnyr

--- a/.github/config/mute_rules.md
+++ b/.github/config/mute_rules.md
@@ -1,116 +1,101 @@
-# Mute / Unmute automation runbook
+# 📖 Простые правила mute / unmute
 
-This document describes the **current** behavior of mute automation in this repository.
+Этот файл — короткая памятка для людей: **что произойдет с тестом и почему**.
 
-## Decision rules
+---
 
-Rule thresholds are loaded from:
+## 1) Когда тест замьютится (`to_mute`)
 
-- `.github/config/mute_coordinator_thresholds.json`
-- fallback defaults in `.github/scripts/mute_policy_rules.py`
+Смотрим последние **4 дня**:
 
-### Mute candidate
+- если запусков (`pass + fail`) **больше 10** — нужно минимум **3 fail**
+- если запусков **10 или меньше** — нужно минимум **2 fail**
 
-A test is added to `to_mute` when it is not currently muted and satisfies default mute predicate.
+Пример:
+- 15 запусков, 3 fail → попадет в mute
+- 6 запусков, 2 fail → попадет в mute
 
-Default threshold values:
+---
 
-- window: `4` days
-- if `pass + fail > 10`, require at least `3` fails
-- otherwise require at least `2` fails
+## 2) Когда тест размьютится (`to_unmute`)
 
-### Unmute candidate
+Смотрим последние **7 дней**:
 
-A test is added to `to_unmute` when default unmute predicate passes.
+- запусков (`pass + fail + mute`) не меньше **4**
+- ошибок (`fail + mute`) ровно **0**
 
-Default threshold values:
+Пример:
+- 5 запусков, все успешные → попадет в unmute
 
-- window: `7` days
-- minimum runs `(pass + fail + mute) >= 4`
-- failures `(fail + mute) == 0`
+---
 
-### Delete-from-mute candidate (`to_delete`)
+## 3) Когда тест удаляется из mute (`to_delete`)
 
-A muted test is added to `to_delete` when:
+Смотрим последние **7 дней**:
 
-- it has no runs in the delete window, or
-- it was muted and only skipped in the window.
+- либо запусков нет вообще
+- либо тест был muted и все события были только `skip`
 
-Default delete window: `7` days.
+---
 
-## User-fixed quarantine
+## 4) Карантин для user-fixed тестов
 
-Quarantine logic lives in `.github/scripts/tests/mute_quarantine.py`.
+Если issue по тесту закрыт **пользователем** и с причиной закрытия `COMPLETED`, тест может попасть в карантин:
 
-Signal source: recently closed issues from YDB `issues` table where:
+- `hide` — временно скрываем из итогового muted-файла
+- `stable` — карантин закончился, условия unmute выполнены, остается размьюченным
+- `restore` — карантин закончился, условия unmute не выполнены, возвращаем в muted
 
-- `closed_by_type == "User"`
-- closure reason is `COMPLETED` (non-completed user closures are rejected)
-- issue body maps to current branch/build profile
+Важно:
+- закрытия с `NOT_PLANNED` / `DUPLICATE` и т.п. **не считаются user-fixed**
+- если чтение issues временно недоступно, карантин безопасно отключается для этого прогона
 
-Actions:
+---
 
-- `hide`: test is hidden from generated muted output while quarantine window is active
-- `stable`: quarantine ended and unmute rule is still satisfied
-- `restore`: quarantine ended, unmute rule is not satisfied -> return to muted output
+## 5) Что обновляется автоматически
 
-Fail-safe behavior:
+### Workflow обновления mute
+`.github/workflows/update_muted_ya.yml`
 
-- if issues table path/query fails, quarantine returns empty actions with explicit error code in stats
+- запускается по расписанию (каждый час с 04:00 до 21:00 UTC) и вручную (`workflow_dispatch`)
+- считает кандидатов, строит `mute_update/new_muted_ya.txt`
+- если есть изменения, открывает/обновляет PR с `.github/config/muted_ya.txt`
 
-## Workflows
+### Workflow создания issues
+`.github/workflows/create_issues_for_muted_tests.yml`
 
-### 1) Update muted file
+- срабатывает после merge PR в `main` (для PR с label `mute-unmute`) или вручную
+- создает/обновляет mute issues и обновляет аналитические таблицы
 
-Workflow: `.github/workflows/update_muted_ya.yml`
+---
 
-- schedule: hourly, from `04:00` to `21:00` UTC
-- also supports `workflow_dispatch`
-- generates `mute_update/new_muted_ya.txt`
-- if changed vs base branch file, opens/updates PR with `.github/config/muted_ya.txt`
+## 6) Главные выходные файлы (`mute_update/`)
 
-### 2) Create issues for merged mute PR
+- `to_mute.txt` — что добавить в mute
+- `to_unmute.txt` — что убрать из mute как стабильное
+- `to_delete.txt` — что удалить из mute как неактуальное
+- `new_muted_ya.txt` — итоговый файл, который идет в `.github/config/muted_ya.txt`
+- `muted_ya_changes.txt` — изменения с префиксами:
+  - `+++` добавили в mute
+  - `---` убрали из mute
+  - `xxx` удалили как неактуальное
 
-Workflow: `.github/workflows/create_issues_for_muted_tests.yml`
+Карантинные снапшоты:
+- `quarantine_hidden.txt`
+- `quarantine_restored.txt`
+- `quarantine_stable_unmuted.txt`
 
-- triggers when PR to `main` is merged
-- runs only for PRs with label `mute-unmute`
-- also supports `workflow_dispatch`
-- creates missing mute issues, comments PR, refreshes analytics tables
+Для большинства файлов есть `*_debug.txt` с объяснениями.
 
-## Generated files (`mute_update/`)
+---
 
-### Core action files
+## 7) Где менять пороги
 
-| File | Meaning |
-|---|---|
-| `to_mute.txt` | Candidates to add into mute |
-| `to_unmute.txt` | Candidates to unmute |
-| `to_delete.txt` | Candidates to remove from mute because they disappeared / only skipped |
-| `muted_ya.txt` | Current muted set reconstructed from monitor rows |
-| `new_muted_ya.txt` | Final output used to update `.github/config/muted_ya.txt` |
+- `.github/config/mute_coordinator_thresholds.json` — основные числа (окна, минимумы)
+- `.github/scripts/mute_policy_rules.py` — fallback-значения и предикаты
 
-### Intermediate snapshots
+---
 
-| File | Meaning |
-|---|---|
-| `muted_ya+to_mute.txt` | current muted + new mute candidates |
-| `muted_ya-to_unmute.txt` | current muted minus unmute candidates |
-| `muted_ya-to_delete.txt` | current muted minus delete candidates |
-| `muted_ya-to-delete-to-unmute.txt` | current muted minus delete and unmute |
-| `muted_ya-to-delete-to-unmute+to_mute.txt` | pre-final merged set before copying to `new_muted_ya.txt` |
-| `muted_ya_changes.txt` | combined diff-like view (`+++`, `---`, `xxx`) |
+## 8) Дашборд
 
-### Quarantine snapshots
-
-| File | Meaning |
-|---|---|
-| `quarantine_hidden.txt` | hidden during quarantine |
-| `quarantine_restored.txt` | restored after failed quarantine |
-| `quarantine_stable_unmuted.txt` | stayed unmuted after quarantine |
-
-For most `.txt` files, a corresponding `*_debug.txt` file is generated with decision context.
-
-## Dashboards
-
-- Main test analytics dashboard: https://datalens.yandex/4un3zdm0zcnyr
+- https://datalens.yandex/4un3zdm0zcnyr

--- a/.github/config/mute_rules.md
+++ b/.github/config/mute_rules.md
@@ -4,6 +4,18 @@ This is a short human-readable guide that explains when tests are muted or unmut
 
 ---
 
+## Time windows (at a glance)
+
+- **Mute window:** last **4 days**
+- **Unmute window:** last **7 days**
+- **Delete-from-mute window:** last **7 days**
+- **User-fixed quarantine window:** configured by `quarantine_user_fixed_window_days` (default: **7 days**)
+
+All windows are configurable in:
+- `.github/config/mute_coordinator_thresholds.json`
+
+---
+
 ## MUTE when (`to_mute`)
 
 Look at the last **4 days**:

--- a/.github/scripts/analytics/export_issues_to_ydb.py
+++ b/.github/scripts/analytics/export_issues_to_ydb.py
@@ -114,6 +114,22 @@ def fetch_single_issue(org_name: str, repo_name: str, issue_number: int) -> Opti
             comments {
               totalCount
             }
+            timelineItems(last: 20, itemTypes: [CLOSED_EVENT]) {
+              nodes {
+                __typename
+                ... on ClosedEvent {
+                  actor {
+                    __typename
+                    ... on User {
+                      login
+                    }
+                    ... on Bot {
+                      login
+                    }
+                  }
+                }
+              }
+            }
             repository {
               id
               name
@@ -213,6 +229,22 @@ def fetch_repository_issues(org_name: str = ORG_NAME, repo_name: str = REPO_NAME
               }
               comments {
                 totalCount
+              }
+              timelineItems(last: 20, itemTypes: [CLOSED_EVENT]) {
+                nodes {
+                  __typename
+                  ... on ClosedEvent {
+                    actor {
+                      __typename
+                      ... on User {
+                        login
+                      }
+                      ... on Bot {
+                        login
+                      }
+                    }
+                  }
+                }
               }
               repository {
                 id
@@ -508,6 +540,15 @@ def transform_issues_for_ydb(issues: List[Dict[str, Any]], project_fields: Optio
         
         # Extract state reason (e.g., COMPLETED, DUPLICATE, NOT_PLANNED)
         state_reason = issue.get('stateReason')
+        closed_by_login = None
+        closed_by_type = None
+        for event in reversed(issue.get('timelineItems', {}).get('nodes', []) or []):
+            if event.get('__typename') != 'ClosedEvent':
+                continue
+            actor = event.get('actor') or {}
+            closed_by_login = actor.get('login')
+            closed_by_type = actor.get('__typename')
+            break
         
         # Extract assignees
         assignees = []
@@ -567,6 +608,8 @@ def transform_issues_for_ydb(issues: List[Dict[str, Any]], project_fields: Optio
             'url': issue.get('url', ''),
             'state': issue.get('state', ''),
             'state_reason': state_reason,
+            'closed_by_login': closed_by_login,
+            'closed_by_type': closed_by_type,
             'body': issue.get('body', '') or '',
             'body_text': issue.get('bodyText', ''),
             
@@ -632,6 +675,8 @@ def create_issues_table(ydb_wrapper: YDBWrapper, table_path: str):
             `url` Utf8,
             `state` Utf8,
             `state_reason` Utf8,  -- Reason for closing (COMPLETED, DUPLICATE, NOT_PLANNED)
+            `closed_by_login` Utf8,
+            `closed_by_type` Utf8,
             `body` Utf8,
             `body_text` Utf8,
             
@@ -686,6 +731,19 @@ def create_issues_table(ydb_wrapper: YDBWrapper, table_path: str):
     """
     
     ydb_wrapper.create_table(table_path, create_sql)
+
+    # Keep existing deployments compatible when new columns are introduced.
+    for alter_sql in (
+        f"ALTER TABLE `{table_path}` ADD COLUMN `closed_by_login` Utf8",
+        f"ALTER TABLE `{table_path}` ADD COLUMN `closed_by_type` Utf8",
+    ):
+        try:
+            ydb_wrapper.create_table(table_path, alter_sql)
+        except Exception as exc:
+            message = str(exc).lower()
+            if "already exists" in message or "precondition failed" in message or "exists" in message:
+                continue
+            raise
     
     elapsed = time.time() - start_time
     print(f"BI-optimized table created successfully (took {elapsed:.2f}s)")
@@ -821,6 +879,8 @@ def main():
                 .add_column("url", ydb.OptionalType(ydb.PrimitiveType.Utf8))
                 .add_column("state", ydb.OptionalType(ydb.PrimitiveType.Utf8))
                 .add_column("state_reason", ydb.OptionalType(ydb.PrimitiveType.Utf8))
+                .add_column("closed_by_login", ydb.OptionalType(ydb.PrimitiveType.Utf8))
+                .add_column("closed_by_type", ydb.OptionalType(ydb.PrimitiveType.Utf8))
                 .add_column("body", ydb.OptionalType(ydb.PrimitiveType.Utf8))
                 .add_column("body_text", ydb.OptionalType(ydb.PrimitiveType.Utf8))
                 

--- a/.github/scripts/mute_policy_rules.py
+++ b/.github/scripts/mute_policy_rules.py
@@ -1,0 +1,94 @@
+#!/usr/bin/env python3
+"""
+Shared mute/unmute/quarantine policy thresholds and predicates.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from typing import Dict
+
+
+_CONFIG_PATH = os.path.normpath(
+    os.path.join(
+        os.path.dirname(os.path.abspath(__file__)),
+        "..",
+        "config",
+        "mute_coordinator_thresholds.json",
+    )
+)
+
+
+DEFAULT_THRESHOLDS: Dict[str, int] = {
+    "default_mute_window_days": 4,
+    "default_unmute_window_days": 7,
+    "default_delete_window_days": 7,
+    "default_unmute_min_runs": 4,
+    "default_mute_total_runs_branch_boundary": 10,
+    "default_mute_min_fails_high_volume": 3,
+    "default_mute_min_fails_low_volume": 2,
+    "default_mute_min_fails_medium_volume": 2,
+    "default_mute_medium_volume_total_runs_gt_exclusive": 10,
+    "quarantine_user_fixed_window_days": 7,
+}
+
+
+def load_mute_coordinator_thresholds() -> Dict[str, int]:
+    thresholds = dict(DEFAULT_THRESHOLDS)
+    if not os.path.exists(_CONFIG_PATH):
+        return thresholds
+
+    with open(_CONFIG_PATH, "r", encoding="utf-8") as f:
+        raw = json.load(f)
+
+    for key, value in raw.items():
+        thresholds[key] = int(value)
+    return thresholds
+
+
+def passes_default_mute(pass_count: int, fail_count: int, thresholds: Dict[str, int]) -> bool:
+    total_runs = int(pass_count) + int(fail_count)
+    fail_count = int(fail_count)
+    boundary = int(thresholds["default_mute_total_runs_branch_boundary"])
+    high_volume_fails = int(thresholds["default_mute_min_fails_high_volume"])
+    low_volume_fails = int(thresholds["default_mute_min_fails_low_volume"])
+    medium_volume_fails = int(thresholds["default_mute_min_fails_medium_volume"])
+    medium_volume_boundary = int(thresholds["default_mute_medium_volume_total_runs_gt_exclusive"])
+
+    if (fail_count >= high_volume_fails and total_runs > boundary) or (
+        fail_count >= low_volume_fails and total_runs <= boundary
+    ):
+        return True
+    if medium_volume_fails <= 0:
+        return False
+    return fail_count >= medium_volume_fails and total_runs > medium_volume_boundary
+
+
+def passes_default_unmute(
+    pass_count: int,
+    fail_count: int,
+    mute_count: int,
+    thresholds: Dict[str, int],
+) -> bool:
+    min_runs = int(thresholds["default_unmute_min_runs"])
+    total_runs = int(pass_count) + int(fail_count) + int(mute_count)
+    total_fails = int(fail_count) + int(mute_count)
+    return total_runs >= min_runs and total_fails == 0
+
+
+def is_delete_candidate_counts(
+    pass_count: int,
+    fail_count: int,
+    mute_count: int,
+    skip_count: int,
+    *,
+    is_muted: bool,
+) -> bool:
+    pass_count = int(pass_count)
+    fail_count = int(fail_count)
+    mute_count = int(mute_count)
+    skip_count = int(skip_count)
+    total_runs = pass_count + fail_count + mute_count + skip_count
+    only_skipped_while_muted = is_muted and skip_count > 0 and pass_count == 0 and fail_count == 0 and mute_count == 0
+    return total_runs == 0 or only_skipped_while_muted

--- a/.github/scripts/tests/create_new_muted_ya.py
+++ b/.github/scripts/tests/create_new_muted_ya.py
@@ -476,6 +476,37 @@ def write_file_set(file_path, test_set, debug_list=None, sort_without_prefixes=F
         add_lines_to_file(debug_path, [line + '\n' for line in sorted_debug_list])
     logging.info(f"Created {os.path.basename(file_path)} with {len(sorted_test_set)} tests")
 
+
+def _extract_test_name_from_debug_line(debug_line: str) -> str:
+    return str(debug_line).split(" #", 1)[0]
+
+
+def _filter_debug_lines_by_tests(debug_lines: List[str], allowed_tests: Set[str]) -> List[str]:
+    return [line for line in debug_lines if _extract_test_name_from_debug_line(line) in allowed_tests]
+
+
+def _build_debug_list_for_tests(
+    tests: List[str],
+    test_debug_dict: Dict[str, str],
+    quarantine_debug_map: Optional[Dict[str, str]] = None,
+) -> List[str]:
+    quarantine_debug_map = quarantine_debug_map or {}
+    return [
+        quarantine_debug_map.get(test_name) or test_debug_dict.get(test_name, "NO DEBUG INFO")
+        for test_name in tests
+    ]
+
+
+def _write_snapshot_file(
+    output_path: str,
+    filename: str,
+    tests: Set[str],
+    debug_lines: List[str],
+):
+    sorted_tests = sorted(tests)
+    write_file_set(os.path.join(output_path, filename), sorted_tests, debug_lines)
+
+
 def _normalize_utc_datetime(value) -> Optional[datetime.datetime]:
     if value is None:
         return None
@@ -727,19 +758,22 @@ def apply_and_add_mutes(
             to_delete = sorted(to_delete_set)
             write_file_set(os.path.join(output_path, 'to_unmute.txt'), to_unmute, to_unmute_debug)
             write_file_set(os.path.join(output_path, 'to_delete.txt'), to_delete, to_delete_debug)
-            write_file_set(
-                os.path.join(output_path, 'quarantine_hidden.txt'),
-                sorted(quarantine_hide_set),
+            _write_snapshot_file(
+                output_path,
+                "quarantine_hidden.txt",
+                quarantine_hide_set,
                 list(quarantine_actions.get("hide_debug") or []),
             )
-            write_file_set(
-                os.path.join(output_path, 'quarantine_restored.txt'),
-                sorted(quarantine_restore_set),
+            _write_snapshot_file(
+                output_path,
+                "quarantine_restored.txt",
+                quarantine_restore_set,
                 list(quarantine_actions.get("restore_debug") or []),
             )
-            write_file_set(
-                os.path.join(output_path, 'quarantine_stable_unmuted.txt'),
-                sorted(quarantine_stable_set),
+            _write_snapshot_file(
+                output_path,
+                "quarantine_stable_unmuted.txt",
+                quarantine_stable_set,
                 list(quarantine_actions.get("stable_debug") or []),
             )
 
@@ -781,34 +815,38 @@ def apply_and_add_mutes(
 
         # 5. muted_ya+to_mute
         muted_ya_plus_to_mute = list(all_muted_ya) + [t for t in to_mute if t not in all_muted_ya]
-        muted_ya_plus_to_mute_debug = []
-        for test in muted_ya_plus_to_mute:
-            debug_val = test_debug_dict.get(test, "NO DEBUG INFO")
-            muted_ya_plus_to_mute_debug.append(debug_val)
+        muted_ya_plus_to_mute_debug = _build_debug_list_for_tests(
+            muted_ya_plus_to_mute,
+            test_debug_dict=test_debug_dict,
+            quarantine_debug_map=quarantine_debug_map,
+        )
         write_file_set(os.path.join(output_path, 'muted_ya+to_mute.txt'), muted_ya_plus_to_mute, muted_ya_plus_to_mute_debug)
 
         # 6. muted_ya-to_unmute
         muted_ya_minus_to_unmute = [t for t in all_muted_ya if t not in to_unmute]
-        muted_ya_minus_to_unmute_debug = []
-        for test in muted_ya_minus_to_unmute:
-            debug_val = test_debug_dict.get(test, "NO DEBUG INFO")
-            muted_ya_minus_to_unmute_debug.append(debug_val)
+        muted_ya_minus_to_unmute_debug = _build_debug_list_for_tests(
+            muted_ya_minus_to_unmute,
+            test_debug_dict=test_debug_dict,
+            quarantine_debug_map=quarantine_debug_map,
+        )
         write_file_set(os.path.join(output_path, 'muted_ya-to_unmute.txt'), muted_ya_minus_to_unmute, muted_ya_minus_to_unmute_debug)
 
         # 7. muted_ya-to_delete
         muted_ya_minus_to_delete = [t for t in all_muted_ya if t not in to_delete]
-        muted_ya_minus_to_delete_debug = []
-        for test in muted_ya_minus_to_delete:
-            debug_val = test_debug_dict.get(test, "NO DEBUG INFO")
-            muted_ya_minus_to_delete_debug.append(debug_val)
+        muted_ya_minus_to_delete_debug = _build_debug_list_for_tests(
+            muted_ya_minus_to_delete,
+            test_debug_dict=test_debug_dict,
+            quarantine_debug_map=quarantine_debug_map,
+        )
         write_file_set(os.path.join(output_path, 'muted_ya-to_delete.txt'), muted_ya_minus_to_delete, muted_ya_minus_to_delete_debug)
 
         # 8. muted_ya-to-delete-to-unmute
         muted_ya_minus_to_delete_to_unmute = [t for t in all_muted_ya if t not in to_delete and t not in to_unmute]
-        muted_ya_minus_to_delete_to_unmute_debug = []
-        for test in muted_ya_minus_to_delete_to_unmute:
-            debug_val = test_debug_dict.get(test, "NO DEBUG INFO")
-            muted_ya_minus_to_delete_to_unmute_debug.append(debug_val)
+        muted_ya_minus_to_delete_to_unmute_debug = _build_debug_list_for_tests(
+            muted_ya_minus_to_delete_to_unmute,
+            test_debug_dict=test_debug_dict,
+            quarantine_debug_map=quarantine_debug_map,
+        )
         write_file_set(os.path.join(output_path, 'muted_ya-to-delete-to-unmute.txt'), muted_ya_minus_to_delete_to_unmute, muted_ya_minus_to_delete_to_unmute_debug)
 
         # 9. muted_ya-to-delete-to-unmute+to_mute
@@ -824,10 +862,11 @@ def apply_and_add_mutes(
                 if test_name not in current_set:
                     muted_ya_minus_to_delete_to_unmute_plus_to_mute.append(test_name)
                     current_set.add(test_name)
-        muted_ya_minus_to_delete_to_unmute_plus_to_mute_debug = []
-        for test in muted_ya_minus_to_delete_to_unmute_plus_to_mute:
-            debug_val = quarantine_debug_map.get(test) or test_debug_dict.get(test, "NO DEBUG INFO")
-            muted_ya_minus_to_delete_to_unmute_plus_to_mute_debug.append(debug_val)
+        muted_ya_minus_to_delete_to_unmute_plus_to_mute_debug = _build_debug_list_for_tests(
+            muted_ya_minus_to_delete_to_unmute_plus_to_mute,
+            test_debug_dict=test_debug_dict,
+            quarantine_debug_map=quarantine_debug_map,
+        )
         write_file_set(os.path.join(output_path, 'muted_ya-to-delete-to-unmute+to_mute.txt'), muted_ya_minus_to_delete_to_unmute_plus_to_mute, muted_ya_minus_to_delete_to_unmute_plus_to_mute_debug)
         # Save the same content as new_muted_ya.txt for workflow compatibility.
         write_file_set(os.path.join(output_path, 'new_muted_ya.txt'), muted_ya_minus_to_delete_to_unmute_plus_to_mute, muted_ya_minus_to_delete_to_unmute_plus_to_mute_debug)

--- a/.github/scripts/tests/create_new_muted_ya.py
+++ b/.github/scripts/tests/create_new_muted_ya.py
@@ -26,7 +26,7 @@ sys.path.append(os.path.join(os.path.dirname(__file__), '..', 'analytics'))
 from ydb_wrapper import YDBWrapper
 
 sys.path.append(os.path.join(os.path.dirname(__file__), '..'))
-from github_issue_utils import DEFAULT_BUILD_TYPE, canonical_team_slug, make_profile_id, parse_body
+from github_issue_utils import DEFAULT_BUILD_TYPE, canonical_team_slug, make_profile_id
 from mute_policy_rules import (
     is_delete_candidate_counts,
     load_mute_coordinator_thresholds,
@@ -34,8 +34,9 @@ from mute_policy_rules import (
     passes_default_unmute,
 )
 from mute_quarantine import (
-    classify_quarantine_actions_for_closed_tests,
-    latest_user_closed_at_by_test,
+    apply_quarantine_actions,
+    finalize_new_muted_ya,
+    resolve_user_fixed_quarantine_actions as resolve_user_fixed_quarantine_actions_core,
 )
 
 # Configure logging
@@ -481,14 +482,6 @@ def write_file_set(file_path, test_set, debug_list=None, sort_without_prefixes=F
     logging.info(f"Created {os.path.basename(file_path)} with {len(sorted_test_set)} tests")
 
 
-def _extract_test_name_from_debug_line(debug_line: str) -> str:
-    return str(debug_line).split(" #", 1)[0]
-
-
-def _filter_debug_lines_by_tests(debug_lines: List[str], allowed_tests: Set[str]) -> List[str]:
-    return [line for line in debug_lines if _extract_test_name_from_debug_line(line) in allowed_tests]
-
-
 def _build_debug_list_for_tests(
     tests: List[str],
     test_debug_dict: Dict[str, str],
@@ -511,41 +504,6 @@ def _write_snapshot_file(
     write_file_set(os.path.join(output_path, filename), sorted_tests, debug_lines)
 
 
-def _normalize_utc_datetime(value) -> Optional[datetime.datetime]:
-    if value is None:
-        return None
-    if isinstance(value, datetime.datetime):
-        if value.tzinfo is None:
-            return value.replace(tzinfo=datetime.timezone.utc)
-        return value.astimezone(datetime.timezone.utc)
-    if isinstance(value, int):
-        # YDB scan values can be seconds or microseconds.
-        if value > 10_000_000_000:
-            value = value / 1_000_000
-        return datetime.datetime.fromtimestamp(value, tz=datetime.timezone.utc)
-    return None
-
-
-def _fallback_mute_string_from_full_name(full_name: str) -> Optional[str]:
-    if not full_name or "/" not in full_name:
-        return None
-    testsuite, testcase = full_name.rsplit("/", 1)
-    if not testsuite or not testcase:
-        return None
-    return f"{testsuite} {testcase}"
-
-
-def _build_full_name_to_mute_strings(rows: List[dict]) -> Dict[str, Set[str]]:
-    result: Dict[str, Set[str]] = defaultdict(set)
-    for row in rows:
-        full_name = row.get("full_name")
-        testsuite = row.get("suite_folder")
-        testcase = row.get("test_name")
-        if full_name and testsuite and testcase:
-            result[str(full_name)].add(f"{testsuite} {testcase}")
-    return result
-
-
 def resolve_user_fixed_quarantine_actions(
     ydb_wrapper: YDBWrapper,
     branch: str,
@@ -553,57 +511,21 @@ def resolve_user_fixed_quarantine_actions(
     all_data: List[dict],
     aggregated_for_unmute: List[dict],
 ) -> Dict[str, object]:
-    quarantine_days = int(_THRESHOLDS["quarantine_user_fixed_window_days"])
-    lookback_days = max(quarantine_days * 3, 30)
-    unmute_candidates = {
-        str(test["full_name"])
-        for test in aggregated_for_unmute
-        if test.get("full_name") and is_unmute_candidate(test)
-    }
-
-    try:
-        issues_table = ydb_wrapper.get_table_path("issues")
-    except Exception as exc:
-        logging.warning(f"Quarantine disabled: cannot resolve issues table path: {exc}")
-        return _empty_quarantine_actions()
-
-    query = f"""
-    SELECT issue_number, body, closed_at, closed_by_type
-    FROM `{issues_table}`
-    WHERE state = 'CLOSED'
-      AND closed_at IS NOT NULL
-      AND closed_at >= CurrentUtcTimestamp() - {lookback_days} * Interval("P1D")
-    """
-
-    try:
-        rows = ydb_wrapper.execute_scan_query(
-            query,
-            query_name=f"user_fixed_quarantine_candidates_{branch}_{build_type}",
-        )
-    except Exception as exc:
-        logging.warning(f"Quarantine disabled: cannot query user-fixed closed issues: {exc}")
-        return _empty_quarantine_actions()
-
-    latest_close_by_test = latest_user_closed_at_by_test(
-        rows=rows,
+    actions = resolve_user_fixed_quarantine_actions_core(
+        ydb_wrapper=ydb_wrapper,
         branch=branch,
         build_type=build_type,
-        parse_body_fn=parse_body,
-        default_build_type=DEFAULT_BUILD_TYPE,
-        normalize_utc_datetime_fn=_normalize_utc_datetime,
+        all_data=all_data,
+        aggregated_for_unmute=aggregated_for_unmute,
+        thresholds=_THRESHOLDS,
     )
-    full_name_to_mute_strings = _build_full_name_to_mute_strings(all_data)
-    actions = classify_quarantine_actions_for_closed_tests(
-        latest_close_by_test=latest_close_by_test,
-        unmute_candidates=unmute_candidates,
-        full_name_to_mute_strings=full_name_to_mute_strings,
-        quarantine_days=quarantine_days,
-        fallback_mute_string_fn=_fallback_mute_string_from_full_name,
-    )
+    stats = actions.get("stats") or {}
     logging.info(
         "Resolved user-fixed quarantine actions: "
         f"hide={len(actions['hide'])}, restore={len(actions['restore'])}, "
-        f"stable={len(actions['stable'])}, candidates={len(latest_close_by_test)}"
+        f"stable={len(actions['stable'])}, linked_tests={stats.get('linked_tests', 0)}, "
+        f"rows={stats.get('rows_total', 0)}, state_reason_rejected={stats.get('rows_state_reason_rejected', 0)}, "
+        f"error={stats.get('error', 'none')}"
     )
     return actions
 
@@ -687,31 +609,27 @@ def apply_and_add_mutes(
         )
         write_file_set(os.path.join(output_path, 'muted_ya.txt'), all_muted_ya, all_muted_ya_debug)
         to_mute_set = set(to_mute)
+        all_muted_ya_set = set(all_muted_ya)
+        quarantine_update = apply_quarantine_actions(
+            to_unmute=to_unmute,
+            to_delete=to_delete,
+            to_unmute_debug=to_unmute_debug,
+            to_delete_debug=to_delete_debug,
+            quarantine_actions=quarantine_actions,
+        )
+        to_unmute = list(quarantine_update["to_unmute"])
+        to_delete = list(quarantine_update["to_delete"])
+        to_unmute_debug = list(quarantine_update["to_unmute_debug"])
+        to_delete_debug = list(quarantine_update["to_delete_debug"])
+        quarantine_hide_set = set(quarantine_update["quarantine_hide_set"])
+        quarantine_restore_set = set(quarantine_update["quarantine_restore_set"])
+        quarantine_stable_set = set(quarantine_update["quarantine_stable_set"])
+        quarantine_debug_map = dict(quarantine_update["quarantine_debug_map"])
         to_unmute_set = set(to_unmute)
         to_delete_set = set(to_delete)
-        all_muted_ya_set = set(all_muted_ya)
-        quarantine_hide_set: Set[str] = set()
-        quarantine_restore_set: Set[str] = set()
-        quarantine_stable_set: Set[str] = set()
-        quarantine_debug_map: Dict[str, str] = {}
-        if quarantine_actions:
-            quarantine_hide_set = set(quarantine_actions.get("hide") or set())
-            quarantine_restore_set = set(quarantine_actions.get("restore") or set())
-            quarantine_stable_set = set(quarantine_actions.get("stable") or set())
-            for debug_line in (
-                list(quarantine_actions.get("hide_debug") or [])
-                + list(quarantine_actions.get("restore_debug") or [])
-                + list(quarantine_actions.get("stable_debug") or [])
-            ):
-                test_name = str(debug_line).split(" #", 1)[0]
-                quarantine_debug_map[test_name] = str(debug_line)
-
-            to_unmute_set -= quarantine_hide_set
-            to_delete_set -= quarantine_hide_set
-            to_unmute = sorted(to_unmute_set)
-            to_delete = sorted(to_delete_set)
-            write_file_set(os.path.join(output_path, 'to_unmute.txt'), to_unmute, to_unmute_debug)
-            write_file_set(os.path.join(output_path, 'to_delete.txt'), to_delete, to_delete_debug)
+        write_file_set(os.path.join(output_path, 'to_unmute.txt'), to_unmute, to_unmute_debug)
+        write_file_set(os.path.join(output_path, 'to_delete.txt'), to_delete, to_delete_debug)
+        if quarantine_actions is not None:
             _write_snapshot_file(
                 output_path,
                 "quarantine_hidden.txt",
@@ -805,17 +723,14 @@ def apply_and_add_mutes(
 
         # 9. muted_ya-to-delete-to-unmute+to_mute
         # Use list instead of set to preserve full ordering/compatibility.
-        muted_ya_minus_to_delete_to_unmute_plus_to_mute = list(muted_ya_minus_to_delete_to_unmute) + [t for t in to_mute if t not in muted_ya_minus_to_delete_to_unmute]
-        if quarantine_hide_set:
-            muted_ya_minus_to_delete_to_unmute_plus_to_mute = [
-                t for t in muted_ya_minus_to_delete_to_unmute_plus_to_mute if t not in quarantine_hide_set
-            ]
-        if quarantine_restore_set:
-            current_set = set(muted_ya_minus_to_delete_to_unmute_plus_to_mute)
-            for test_name in sorted(quarantine_restore_set):
-                if test_name not in current_set:
-                    muted_ya_minus_to_delete_to_unmute_plus_to_mute.append(test_name)
-                    current_set.add(test_name)
+        muted_ya_minus_to_delete_to_unmute_plus_to_mute = finalize_new_muted_ya(
+            all_muted_ya=all_muted_ya,
+            to_delete=to_delete,
+            to_unmute=to_unmute,
+            to_mute=to_mute,
+            quarantine_hide_set=quarantine_hide_set,
+            quarantine_restore_set=quarantine_restore_set,
+        )
         muted_ya_minus_to_delete_to_unmute_plus_to_mute_debug = _build_debug_list_for_tests(
             muted_ya_minus_to_delete_to_unmute_plus_to_mute,
             test_debug_dict=test_debug_dict,

--- a/.github/scripts/tests/create_new_muted_ya.py
+++ b/.github/scripts/tests/create_new_muted_ya.py
@@ -33,6 +33,10 @@ from mute_policy_rules import (
     passes_default_mute,
     passes_default_unmute,
 )
+from mute_quarantine import (
+    classify_quarantine_actions_for_closed_tests,
+    latest_user_closed_at_by_test,
+)
 
 # Configure logging
 logging.basicConfig(level=logging.DEBUG, format='%(asctime)s - %(levelname)s - %(message)s')
@@ -561,13 +565,12 @@ def resolve_user_fixed_quarantine_actions(
         issues_table = ydb_wrapper.get_table_path("issues")
     except Exception as exc:
         logging.warning(f"Quarantine disabled: cannot resolve issues table path: {exc}")
-        return {"hide": set(), "restore": set(), "stable": set(), "hide_debug": [], "restore_debug": [], "stable_debug": []}
+        return _empty_quarantine_actions()
 
     query = f"""
-    SELECT issue_number, body, closed_at
+    SELECT issue_number, body, closed_at, closed_by_type
     FROM `{issues_table}`
     WHERE state = 'CLOSED'
-      AND closed_by_type = 'User'
       AND closed_at IS NOT NULL
       AND closed_at >= CurrentUtcTimestamp() - {lookback_days} * Interval("P1D")
     """
@@ -579,79 +582,30 @@ def resolve_user_fixed_quarantine_actions(
         )
     except Exception as exc:
         logging.warning(f"Quarantine disabled: cannot query user-fixed closed issues: {exc}")
-        return {"hide": set(), "restore": set(), "stable": set(), "hide_debug": [], "restore_debug": [], "stable_debug": []}
+        return _empty_quarantine_actions()
 
-    latest_close_by_test: Dict[str, datetime.datetime] = {}
-    for row in rows:
-        body = str(row.get("body") or "")
-        if not body:
-            continue
-        closed_at = _normalize_utc_datetime(row.get("closed_at"))
-        if closed_at is None:
-            continue
-        parsed = parse_body(body)
-        issue_build_type = parsed.build_type or DEFAULT_BUILD_TYPE
-        issue_branches = parsed.branches or ["main"]
-        if issue_build_type != build_type or branch not in issue_branches:
-            continue
-
-        for full_name in parsed.tests:
-            if not full_name:
-                continue
-            prev_closed_at = latest_close_by_test.get(full_name)
-            if prev_closed_at is None or closed_at > prev_closed_at:
-                latest_close_by_test[full_name] = closed_at
-
+    latest_close_by_test = latest_user_closed_at_by_test(
+        rows=rows,
+        branch=branch,
+        build_type=build_type,
+        parse_body_fn=parse_body,
+        default_build_type=DEFAULT_BUILD_TYPE,
+        normalize_utc_datetime_fn=_normalize_utc_datetime,
+    )
     full_name_to_mute_strings = _build_full_name_to_mute_strings(all_data)
-    now_utc = datetime.datetime.now(datetime.timezone.utc)
-    hide: Set[str] = set()
-    restore: Set[str] = set()
-    stable: Set[str] = set()
-    hide_debug: List[str] = []
-    restore_debug: List[str] = []
-    stable_debug: List[str] = []
-
-    for full_name, closed_at in latest_close_by_test.items():
-        mute_strings = set(full_name_to_mute_strings.get(full_name) or set())
-        if not mute_strings:
-            fallback = _fallback_mute_string_from_full_name(full_name)
-            if fallback:
-                mute_strings.add(fallback)
-        if not mute_strings:
-            continue
-
-        age_days = max(0, (now_utc.date() - closed_at.date()).days)
-        if age_days < quarantine_days:
-            hide.update(mute_strings)
-            for mute_str in sorted(mute_strings):
-                hide_debug.append(
-                    f"{mute_str} # quarantine_user_fixed active: closed {age_days}d ago, window={quarantine_days}d"
-                )
-        elif full_name in unmute_candidates:
-            stable.update(mute_strings)
-            for mute_str in sorted(mute_strings):
-                stable_debug.append(
-                    f"{mute_str} # quarantine_user_fixed passed: window ended and default unmute rule passed"
-                )
-        else:
-            restore.update(mute_strings)
-            for mute_str in sorted(mute_strings):
-                restore_debug.append(
-                    f"{mute_str} # quarantine_user_fixed expired without unmute conditions, restoring to muted"
-                )
-
+    actions = classify_quarantine_actions_for_closed_tests(
+        latest_close_by_test=latest_close_by_test,
+        unmute_candidates=unmute_candidates,
+        full_name_to_mute_strings=full_name_to_mute_strings,
+        quarantine_days=quarantine_days,
+        fallback_mute_string_fn=_fallback_mute_string_from_full_name,
+    )
     logging.info(
         "Resolved user-fixed quarantine actions: "
-        f"hide={len(hide)}, restore={len(restore)}, stable={len(stable)}, candidates={len(latest_close_by_test)}"
+        f"hide={len(actions['hide'])}, restore={len(actions['restore'])}, "
+        f"stable={len(actions['stable'])}, candidates={len(latest_close_by_test)}"
     )
-    return {
-        "hide": hide,
-        "restore": restore,
-        "stable": stable,
-        "hide_debug": sorted(hide_debug),
-        "restore_debug": sorted(restore_debug),
-        "stable_debug": sorted(stable_debug),
-    }
+    return actions
 
 
 def apply_and_add_mutes(

--- a/.github/scripts/tests/create_new_muted_ya.py
+++ b/.github/scripts/tests/create_new_muted_ya.py
@@ -8,6 +8,7 @@ import ydb
 import logging
 import sys
 from collections import defaultdict
+from typing import Dict, List, Optional, Set
 
 # Add the parent directory to the path to import update_mute_issues
 sys.path.append(os.path.dirname(os.path.abspath(__file__)))
@@ -25,7 +26,13 @@ sys.path.append(os.path.join(os.path.dirname(__file__), '..', 'analytics'))
 from ydb_wrapper import YDBWrapper
 
 sys.path.append(os.path.join(os.path.dirname(__file__), '..'))
-from github_issue_utils import DEFAULT_BUILD_TYPE, canonical_team_slug, make_profile_id
+from github_issue_utils import DEFAULT_BUILD_TYPE, canonical_team_slug, make_profile_id, parse_body
+from mute_policy_rules import (
+    is_delete_candidate_counts,
+    load_mute_coordinator_thresholds,
+    passes_default_mute,
+    passes_default_unmute,
+)
 
 # Configure logging
 logging.basicConfig(level=logging.DEBUG, format='%(asctime)s - %(levelname)s - %(message)s')
@@ -34,10 +41,10 @@ dir = os.path.dirname(__file__)
 repo_path = f"{dir}/../../../"
 muted_ya_path = '.github/config/muted_ya.txt'
 
-# Constants for mute logic time windows
-MUTE_DAYS = 4
-UNMUTE_DAYS = 7
-DELETE_DAYS = 7
+_THRESHOLDS = load_mute_coordinator_thresholds()
+MUTE_DAYS = _THRESHOLDS["default_mute_window_days"]
+UNMUTE_DAYS = _THRESHOLDS["default_unmute_window_days"]
+DELETE_DAYS = _THRESHOLDS["default_delete_window_days"]
 
 _DIGEST_NOTIFICATION_CONFIG = os.path.normpath(
     os.path.join(dir, '..', '..', 'config', 'mute_issue_and_digest_config.json')
@@ -352,9 +359,10 @@ def is_mute_candidate(test):
     if test.get('is_muted', False):
         return False
 
-    total_runs = test.get('pass_count', 0) + test.get('fail_count', 0)
+    pass_count = test.get('pass_count', 0)
     fail_count = test.get('fail_count', 0)
-    result = (fail_count >= 3 and total_runs > 10) or (fail_count >= 2 and total_runs <= 10)
+    total_runs = pass_count + fail_count
+    result = passes_default_mute(pass_count, fail_count, _THRESHOLDS)
 
     logging.debug(f"MUTE_CHECK: {test.get('full_name')} - runs:{total_runs}, fails:{fail_count}, state:{test.get('state')}, muted:{test.get('is_muted')}, result:{result}")
 
@@ -362,10 +370,13 @@ def is_mute_candidate(test):
 
 def is_unmute_candidate(test):
     """Check whether a test is an unmute candidate for the given period."""
-    total_runs = test.get('pass_count', 0) + test.get('fail_count', 0) + test.get('mute_count', 0)
-    total_fails = test.get('fail_count', 0) + test.get('mute_count', 0)
+    pass_count = test.get('pass_count', 0)
+    fail_count = test.get('fail_count', 0)
+    mute_count = test.get('mute_count', 0)
+    total_runs = pass_count + fail_count + mute_count
+    total_fails = fail_count + mute_count
 
-    result = total_runs >= 4 and total_fails == 0
+    result = passes_default_unmute(pass_count, fail_count, mute_count, _THRESHOLDS)
 
     if test.get('is_muted', False):
         logging.debug(f"UNMUTE_CHECK: {test.get('full_name')} - runs:{total_runs}, fails:{total_fails}, mute_count:{test.get('mute_count')}, state:{test.get('state')}, muted:{test.get('is_muted')}, result:{result}")
@@ -374,20 +385,26 @@ def is_unmute_candidate(test):
 
 def is_delete_candidate(test):
     """Check whether a test is a delete-from-mute candidate for the given period."""
-    pass_count = test.get('pass_count', 0)
-    fail_count = test.get('fail_count', 0)
-    mute_count = test.get('mute_count', 0)
-    skip_count = test.get('skip_count', 0)
+    pass_count = int(test.get('pass_count', 0) or 0)
+    fail_count = int(test.get('fail_count', 0) or 0)
+    mute_count = int(test.get('mute_count', 0) or 0)
+    skip_count = int(test.get('skip_count', 0) or 0)
     total_runs = pass_count + fail_count + mute_count + skip_count
 
     only_skipped_while_muted = (
-        test.get('is_muted', False)
+        bool(test.get('is_muted', False))
         and skip_count > 0
         and pass_count == 0
         and fail_count == 0
         and mute_count == 0
     )
-    result = total_runs == 0 or only_skipped_while_muted
+    result = is_delete_candidate_counts(
+        pass_count,
+        fail_count,
+        mute_count,
+        skip_count,
+        is_muted=bool(test.get('is_muted', False)),
+    )
 
     if test.get('is_muted', False):
         logging.debug(
@@ -459,7 +476,162 @@ def write_file_set(file_path, test_set, debug_list=None, sort_without_prefixes=F
         add_lines_to_file(debug_path, [line + '\n' for line in sorted_debug_list])
     logging.info(f"Created {os.path.basename(file_path)} with {len(sorted_test_set)} tests")
 
-def apply_and_add_mutes(all_data, output_path, mute_check, aggregated_for_mute, aggregated_for_unmute, aggregated_for_delete):
+def _normalize_utc_datetime(value) -> Optional[datetime.datetime]:
+    if value is None:
+        return None
+    if isinstance(value, datetime.datetime):
+        if value.tzinfo is None:
+            return value.replace(tzinfo=datetime.timezone.utc)
+        return value.astimezone(datetime.timezone.utc)
+    if isinstance(value, int):
+        # YDB scan values can be seconds or microseconds.
+        if value > 10_000_000_000:
+            value = value / 1_000_000
+        return datetime.datetime.fromtimestamp(value, tz=datetime.timezone.utc)
+    return None
+
+
+def _fallback_mute_string_from_full_name(full_name: str) -> Optional[str]:
+    if not full_name or "/" not in full_name:
+        return None
+    testsuite, testcase = full_name.rsplit("/", 1)
+    if not testsuite or not testcase:
+        return None
+    return f"{testsuite} {testcase}"
+
+
+def _build_full_name_to_mute_strings(rows: List[dict]) -> Dict[str, Set[str]]:
+    result: Dict[str, Set[str]] = defaultdict(set)
+    for row in rows:
+        full_name = row.get("full_name")
+        testsuite = row.get("suite_folder")
+        testcase = row.get("test_name")
+        if full_name and testsuite and testcase:
+            result[str(full_name)].add(f"{testsuite} {testcase}")
+    return result
+
+
+def resolve_user_fixed_quarantine_actions(
+    ydb_wrapper: YDBWrapper,
+    branch: str,
+    build_type: str,
+    all_data: List[dict],
+    aggregated_for_unmute: List[dict],
+) -> Dict[str, object]:
+    quarantine_days = int(_THRESHOLDS["quarantine_user_fixed_window_days"])
+    lookback_days = max(quarantine_days * 3, 30)
+    unmute_candidates = {
+        str(test["full_name"])
+        for test in aggregated_for_unmute
+        if test.get("full_name") and is_unmute_candidate(test)
+    }
+
+    try:
+        issues_table = ydb_wrapper.get_table_path("issues")
+    except Exception as exc:
+        logging.warning(f"Quarantine disabled: cannot resolve issues table path: {exc}")
+        return {"hide": set(), "restore": set(), "stable": set(), "hide_debug": [], "restore_debug": [], "stable_debug": []}
+
+    query = f"""
+    SELECT issue_number, body, closed_at
+    FROM `{issues_table}`
+    WHERE state = 'CLOSED'
+      AND closed_by_type = 'User'
+      AND closed_at IS NOT NULL
+      AND closed_at >= CurrentUtcTimestamp() - {lookback_days} * Interval("P1D")
+    """
+
+    try:
+        rows = ydb_wrapper.execute_scan_query(
+            query,
+            query_name=f"user_fixed_quarantine_candidates_{branch}_{build_type}",
+        )
+    except Exception as exc:
+        logging.warning(f"Quarantine disabled: cannot query user-fixed closed issues: {exc}")
+        return {"hide": set(), "restore": set(), "stable": set(), "hide_debug": [], "restore_debug": [], "stable_debug": []}
+
+    latest_close_by_test: Dict[str, datetime.datetime] = {}
+    for row in rows:
+        body = str(row.get("body") or "")
+        if not body:
+            continue
+        closed_at = _normalize_utc_datetime(row.get("closed_at"))
+        if closed_at is None:
+            continue
+        parsed = parse_body(body)
+        issue_build_type = parsed.build_type or DEFAULT_BUILD_TYPE
+        issue_branches = parsed.branches or ["main"]
+        if issue_build_type != build_type or branch not in issue_branches:
+            continue
+
+        for full_name in parsed.tests:
+            if not full_name:
+                continue
+            prev_closed_at = latest_close_by_test.get(full_name)
+            if prev_closed_at is None or closed_at > prev_closed_at:
+                latest_close_by_test[full_name] = closed_at
+
+    full_name_to_mute_strings = _build_full_name_to_mute_strings(all_data)
+    now_utc = datetime.datetime.now(datetime.timezone.utc)
+    hide: Set[str] = set()
+    restore: Set[str] = set()
+    stable: Set[str] = set()
+    hide_debug: List[str] = []
+    restore_debug: List[str] = []
+    stable_debug: List[str] = []
+
+    for full_name, closed_at in latest_close_by_test.items():
+        mute_strings = set(full_name_to_mute_strings.get(full_name) or set())
+        if not mute_strings:
+            fallback = _fallback_mute_string_from_full_name(full_name)
+            if fallback:
+                mute_strings.add(fallback)
+        if not mute_strings:
+            continue
+
+        age_days = max(0, (now_utc.date() - closed_at.date()).days)
+        if age_days < quarantine_days:
+            hide.update(mute_strings)
+            for mute_str in sorted(mute_strings):
+                hide_debug.append(
+                    f"{mute_str} # quarantine_user_fixed active: closed {age_days}d ago, window={quarantine_days}d"
+                )
+        elif full_name in unmute_candidates:
+            stable.update(mute_strings)
+            for mute_str in sorted(mute_strings):
+                stable_debug.append(
+                    f"{mute_str} # quarantine_user_fixed passed: window ended and default unmute rule passed"
+                )
+        else:
+            restore.update(mute_strings)
+            for mute_str in sorted(mute_strings):
+                restore_debug.append(
+                    f"{mute_str} # quarantine_user_fixed expired without unmute conditions, restoring to muted"
+                )
+
+    logging.info(
+        "Resolved user-fixed quarantine actions: "
+        f"hide={len(hide)}, restore={len(restore)}, stable={len(stable)}, candidates={len(latest_close_by_test)}"
+    )
+    return {
+        "hide": hide,
+        "restore": restore,
+        "stable": stable,
+        "hide_debug": sorted(hide_debug),
+        "restore_debug": sorted(restore_debug),
+        "stable_debug": sorted(stable_debug),
+    }
+
+
+def apply_and_add_mutes(
+    all_data,
+    output_path,
+    mute_check,
+    aggregated_for_mute,
+    aggregated_for_unmute,
+    aggregated_for_delete,
+    quarantine_actions=None,
+):
     output_path = os.path.join(output_path, 'mute_update')
     logging.info(f"Creating mute files in directory: {output_path}")
     
@@ -533,8 +705,45 @@ def apply_and_add_mutes(all_data, output_path, mute_check, aggregated_for_mute, 
         to_unmute_set = set(to_unmute)
         to_delete_set = set(to_delete)
         all_muted_ya_set = set(all_muted_ya)
-        
-         # Build maps for fast debug string lookup.
+        quarantine_hide_set: Set[str] = set()
+        quarantine_restore_set: Set[str] = set()
+        quarantine_stable_set: Set[str] = set()
+        quarantine_debug_map: Dict[str, str] = {}
+        if quarantine_actions:
+            quarantine_hide_set = set(quarantine_actions.get("hide") or set())
+            quarantine_restore_set = set(quarantine_actions.get("restore") or set())
+            quarantine_stable_set = set(quarantine_actions.get("stable") or set())
+            for debug_line in (
+                list(quarantine_actions.get("hide_debug") or [])
+                + list(quarantine_actions.get("restore_debug") or [])
+                + list(quarantine_actions.get("stable_debug") or [])
+            ):
+                test_name = str(debug_line).split(" #", 1)[0]
+                quarantine_debug_map[test_name] = str(debug_line)
+
+            to_unmute_set -= quarantine_hide_set
+            to_delete_set -= quarantine_hide_set
+            to_unmute = sorted(to_unmute_set)
+            to_delete = sorted(to_delete_set)
+            write_file_set(os.path.join(output_path, 'to_unmute.txt'), to_unmute, to_unmute_debug)
+            write_file_set(os.path.join(output_path, 'to_delete.txt'), to_delete, to_delete_debug)
+            write_file_set(
+                os.path.join(output_path, 'quarantine_hidden.txt'),
+                sorted(quarantine_hide_set),
+                list(quarantine_actions.get("hide_debug") or []),
+            )
+            write_file_set(
+                os.path.join(output_path, 'quarantine_restored.txt'),
+                sorted(quarantine_restore_set),
+                list(quarantine_actions.get("restore_debug") or []),
+            )
+            write_file_set(
+                os.path.join(output_path, 'quarantine_stable_unmuted.txt'),
+                sorted(quarantine_stable_set),
+                list(quarantine_actions.get("stable_debug") or []),
+            )
+
+        # Build maps for fast debug string lookup.
 
         # Universal map: key is test string (with or without wildcard), value is debug string.
         test_debug_dict = {}
@@ -605,22 +814,39 @@ def apply_and_add_mutes(all_data, output_path, mute_check, aggregated_for_mute, 
         # 9. muted_ya-to-delete-to-unmute+to_mute
         # Use list instead of set to preserve full ordering/compatibility.
         muted_ya_minus_to_delete_to_unmute_plus_to_mute = list(muted_ya_minus_to_delete_to_unmute) + [t for t in to_mute if t not in muted_ya_minus_to_delete_to_unmute]
+        if quarantine_hide_set:
+            muted_ya_minus_to_delete_to_unmute_plus_to_mute = [
+                t for t in muted_ya_minus_to_delete_to_unmute_plus_to_mute if t not in quarantine_hide_set
+            ]
+        if quarantine_restore_set:
+            current_set = set(muted_ya_minus_to_delete_to_unmute_plus_to_mute)
+            for test_name in sorted(quarantine_restore_set):
+                if test_name not in current_set:
+                    muted_ya_minus_to_delete_to_unmute_plus_to_mute.append(test_name)
+                    current_set.add(test_name)
         muted_ya_minus_to_delete_to_unmute_plus_to_mute_debug = []
         for test in muted_ya_minus_to_delete_to_unmute_plus_to_mute:
-            debug_val = test_debug_dict.get(test, "NO DEBUG INFO")
+            debug_val = quarantine_debug_map.get(test) or test_debug_dict.get(test, "NO DEBUG INFO")
             muted_ya_minus_to_delete_to_unmute_plus_to_mute_debug.append(debug_val)
         write_file_set(os.path.join(output_path, 'muted_ya-to-delete-to-unmute+to_mute.txt'), muted_ya_minus_to_delete_to_unmute_plus_to_mute, muted_ya_minus_to_delete_to_unmute_plus_to_mute_debug)
         # Save the same content as new_muted_ya.txt for workflow compatibility.
         write_file_set(os.path.join(output_path, 'new_muted_ya.txt'), muted_ya_minus_to_delete_to_unmute_plus_to_mute, muted_ya_minus_to_delete_to_unmute_plus_to_mute_debug)
         
         # 10. muted_ya_changes - changes file (new logic).
-        all_test_strings = sorted(all_muted_ya_set | to_mute_set | to_unmute_set | to_delete_set, key=sort_key_without_prefix)
+        all_test_strings = sorted(
+            all_muted_ya_set | to_mute_set | to_unmute_set | to_delete_set | quarantine_hide_set | quarantine_restore_set,
+            key=sort_key_without_prefix,
+        )
         # Ensure 1:1 correspondence between .txt and debug.txt.
         muted_ya_changes = []
         muted_ya_changes_debug = []
         for test_str in all_test_strings:  # all_test_strings must be a list, not a set.
             if test_str in to_mute_set and test_str not in all_muted_ya_set:
                 prefix = "+++"
+            elif test_str in quarantine_restore_set and test_str not in all_muted_ya_set:
+                prefix = "+++"
+            elif test_str in quarantine_hide_set:
+                prefix = "---"
             elif test_str in to_unmute_set:
                 prefix = "---"
             elif test_str in to_delete_set:
@@ -629,7 +855,7 @@ def apply_and_add_mutes(all_data, output_path, mute_check, aggregated_for_mute, 
                 prefix = ""
             line = f"{prefix} {test_str}" if prefix else f"{test_str}"
             muted_ya_changes.append(line)
-            debug_val = test_debug_dict.get(test_str, "NO DEBUG INFO")
+            debug_val = quarantine_debug_map.get(test_str) or test_debug_dict.get(test_str, "NO DEBUG INFO")
             muted_ya_changes_debug.append(f"{prefix} {debug_val}" if prefix else debug_val)
         write_file_set(os.path.join(output_path, 'muted_ya_changes.txt'), muted_ya_changes, muted_ya_changes_debug, sort_without_prefixes=True)
         
@@ -643,6 +869,9 @@ def apply_and_add_mutes(all_data, output_path, mute_check, aggregated_for_mute, 
         logging.info(f"muted_ya-to_delete: {len(muted_ya_minus_to_delete)}")
         logging.info(f"muted_ya-to_delete-to_unmute: {len(muted_ya_minus_to_delete_to_unmute)}")
         logging.info(f"muted_ya-to_delete-to_unmute+to_mute: {len(muted_ya_minus_to_delete_to_unmute_plus_to_mute)}")
+        logging.info(
+            f"quarantine: hide={len(quarantine_hide_set)}, restore={len(quarantine_restore_set)}, stable={len(quarantine_stable_set)}"
+        )
         
     except (KeyError, TypeError) as e:
         logging.error(f"Error processing test data: {e}. Check your query results for valid keys.")
@@ -1033,7 +1262,22 @@ def mute_worker(args):
             output_path = args.output_folder
             os.makedirs(output_path, exist_ok=True)
             logging.info(f"Creating mute files in: {output_path}")
-            apply_and_add_mutes(all_data, output_path, mute_check, aggregated_for_mute, aggregated_for_unmute, aggregated_for_delete)
+            quarantine_actions = resolve_user_fixed_quarantine_actions(
+                ydb_wrapper=ydb_wrapper,
+                branch=args.branch,
+                build_type=build_type,
+                all_data=all_data,
+                aggregated_for_unmute=aggregated_for_unmute,
+            )
+            apply_and_add_mutes(
+                all_data,
+                output_path,
+                mute_check,
+                aggregated_for_mute,
+                aggregated_for_unmute,
+                aggregated_for_delete,
+                quarantine_actions=quarantine_actions,
+            )
 
         elif args.mode == 'create_issues':
             file_path = args.file_path

--- a/.github/scripts/tests/mute_quarantine.py
+++ b/.github/scripts/tests/mute_quarantine.py
@@ -69,6 +69,7 @@ def extract_latest_user_closed_tests(
         "rows_total": 0,
         "rows_user_closed": 0,
         "rows_missing_closed_by_type": 0,
+        "rows_state_reason_rejected": 0,
         "rows_without_body": 0,
         "rows_without_closed_at": 0,
         "rows_parse_error": 0,
@@ -86,6 +87,14 @@ def extract_latest_user_closed_tests(
         if str(closed_by_type) != "User":
             continue
         stats["rows_user_closed"] += 1
+
+        # Treat only "completed" user closures as "user fixed" signal.
+        # Other closure reasons (for example not-planned / duplicate flows)
+        # should not start quarantine for muted tests.
+        state_reason = str(row.get("state_reason") or "").upper()
+        if state_reason and state_reason != "COMPLETED":
+            stats["rows_state_reason_rejected"] += 1
+            continue
 
         body = str(row.get("body") or "")
         if not body:
@@ -259,7 +268,7 @@ def resolve_user_fixed_quarantine_actions(
         return out
 
     query = f"""
-    SELECT issue_number, body, closed_at, closed_by_type
+    SELECT issue_number, body, closed_at, closed_by_type, state_reason
     FROM `{issues_table}`
     WHERE state = 'CLOSED'
       AND closed_at IS NOT NULL
@@ -362,4 +371,37 @@ def finalize_new_muted_ya(
         to_delete=set(to_delete),
         quarantine_hide=quarantine_hide_set,
         quarantine_restore=quarantine_restore_set,
+    )
+
+
+# Backward-compatible aliases for callers that imported the old names during
+# intermediate refactors.
+def latest_user_closed_at_by_test(
+    rows: List[dict],
+    branch: str,
+    build_type: str,
+    parse_body_fn=parse_body,
+    default_build_type: str = DEFAULT_BUILD_TYPE,
+    normalize_utc_datetime_fn=normalize_utc_datetime,
+) -> Dict[str, datetime.datetime]:
+    _ = parse_body_fn
+    _ = default_build_type
+    _ = normalize_utc_datetime_fn
+    latest, _stats = extract_latest_user_closed_tests(rows, branch, build_type)
+    return latest
+
+
+def classify_quarantine_actions_for_closed_tests(
+    latest_close_by_test: Dict[str, datetime.datetime],
+    unmute_candidates: Set[str],
+    full_name_to_mute_strings: Dict[str, Set[str]],
+    quarantine_days: int,
+    fallback_mute_string_fn=fallback_mute_string_from_full_name,
+) -> Dict[str, object]:
+    _ = fallback_mute_string_fn
+    return compute_user_fixed_quarantine_actions(
+        latest_close_by_test=latest_close_by_test,
+        full_name_to_mute_strings=full_name_to_mute_strings,
+        unmute_candidates=unmute_candidates,
+        quarantine_days=quarantine_days,
     )

--- a/.github/scripts/tests/mute_quarantine.py
+++ b/.github/scripts/tests/mute_quarantine.py
@@ -1,0 +1,365 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import datetime
+import os
+import sys
+from collections import defaultdict
+from typing import Dict, List, Optional, Set, Tuple
+
+sys.path.append(os.path.join(os.path.dirname(__file__), ".."))
+from github_issue_utils import DEFAULT_BUILD_TYPE, parse_body
+from mute_policy_rules import DEFAULT_THRESHOLDS, passes_default_unmute
+
+
+def empty_quarantine_actions() -> Dict[str, object]:
+    return {
+        "hide": set(),
+        "restore": set(),
+        "stable": set(),
+        "hide_debug": [],
+        "restore_debug": [],
+        "stable_debug": [],
+        "stats": {},
+    }
+
+
+def normalize_utc_datetime(value) -> Optional[datetime.datetime]:
+    if value is None:
+        return None
+    if isinstance(value, datetime.datetime):
+        if value.tzinfo is None:
+            return value.replace(tzinfo=datetime.timezone.utc)
+        return value.astimezone(datetime.timezone.utc)
+    if isinstance(value, int):
+        # YDB scan values can be seconds or microseconds.
+        if value > 10_000_000_000:
+            value = value / 1_000_000
+        return datetime.datetime.fromtimestamp(value, tz=datetime.timezone.utc)
+    return None
+
+
+def fallback_mute_string_from_full_name(full_name: str) -> Optional[str]:
+    if not full_name or "/" not in full_name:
+        return None
+    testsuite, testcase = full_name.rsplit("/", 1)
+    if not testsuite or not testcase:
+        return None
+    return f"{testsuite} {testcase}"
+
+
+def build_full_name_to_mute_strings(rows: List[dict]) -> Dict[str, Set[str]]:
+    result: Dict[str, Set[str]] = defaultdict(set)
+    for row in rows:
+        full_name = row.get("full_name")
+        testsuite = row.get("suite_folder")
+        testcase = row.get("test_name")
+        if full_name and testsuite and testcase:
+            result[str(full_name)].add(f"{testsuite} {testcase}")
+    return result
+
+
+def extract_latest_user_closed_tests(
+    rows: List[dict],
+    branch: str,
+    build_type: str,
+) -> Tuple[Dict[str, datetime.datetime], Dict[str, int]]:
+    latest_close_by_test: Dict[str, datetime.datetime] = {}
+    stats = {
+        "rows_total": 0,
+        "rows_user_closed": 0,
+        "rows_missing_closed_by_type": 0,
+        "rows_without_body": 0,
+        "rows_without_closed_at": 0,
+        "rows_parse_error": 0,
+        "rows_branch_or_build_mismatch": 0,
+        "rows_without_tests": 0,
+        "linked_tests": 0,
+    }
+
+    for row in rows:
+        stats["rows_total"] += 1
+        closed_by_type = row.get("closed_by_type")
+        if not closed_by_type:
+            stats["rows_missing_closed_by_type"] += 1
+            continue
+        if str(closed_by_type) != "User":
+            continue
+        stats["rows_user_closed"] += 1
+
+        body = str(row.get("body") or "")
+        if not body:
+            stats["rows_without_body"] += 1
+            continue
+
+        closed_at = normalize_utc_datetime(row.get("closed_at"))
+        if closed_at is None:
+            stats["rows_without_closed_at"] += 1
+            continue
+
+        try:
+            parsed = parse_body(body)
+        except Exception:
+            stats["rows_parse_error"] += 1
+            continue
+
+        issue_build_type = parsed.build_type or DEFAULT_BUILD_TYPE
+        issue_branches = parsed.branches or ["main"]
+        if issue_build_type != build_type or branch not in issue_branches:
+            stats["rows_branch_or_build_mismatch"] += 1
+            continue
+
+        tests = [name for name in parsed.tests if name]
+        if not tests:
+            stats["rows_without_tests"] += 1
+            continue
+
+        for full_name in tests:
+            stats["linked_tests"] += 1
+            prev_closed_at = latest_close_by_test.get(full_name)
+            if prev_closed_at is None or closed_at > prev_closed_at:
+                latest_close_by_test[full_name] = closed_at
+
+    return latest_close_by_test, stats
+
+
+def compute_user_fixed_quarantine_actions(
+    latest_close_by_test: Dict[str, datetime.datetime],
+    full_name_to_mute_strings: Dict[str, Set[str]],
+    unmute_candidates: Set[str],
+    quarantine_days: int,
+    now_utc: Optional[datetime.datetime] = None,
+) -> Dict[str, object]:
+    now_utc = now_utc or datetime.datetime.now(datetime.timezone.utc)
+    hide: Set[str] = set()
+    restore: Set[str] = set()
+    stable: Set[str] = set()
+    hide_debug: List[str] = []
+    restore_debug: List[str] = []
+    stable_debug: List[str] = []
+
+    for full_name, closed_at in latest_close_by_test.items():
+        mute_strings = set(full_name_to_mute_strings.get(full_name) or set())
+        if not mute_strings:
+            fallback = fallback_mute_string_from_full_name(full_name)
+            if fallback:
+                mute_strings.add(fallback)
+        if not mute_strings:
+            continue
+
+        age_days = max(0, (now_utc.date() - closed_at.date()).days)
+        if age_days < quarantine_days:
+            hide.update(mute_strings)
+            for mute_str in sorted(mute_strings):
+                hide_debug.append(
+                    f"{mute_str} # quarantine_user_fixed active: closed {age_days}d ago, window={quarantine_days}d"
+                )
+        elif full_name in unmute_candidates:
+            stable.update(mute_strings)
+            for mute_str in sorted(mute_strings):
+                stable_debug.append(
+                    f"{mute_str} # quarantine_user_fixed passed: window ended and default unmute rule passed"
+                )
+        else:
+            restore.update(mute_strings)
+            for mute_str in sorted(mute_strings):
+                restore_debug.append(
+                    f"{mute_str} # quarantine_user_fixed expired without unmute conditions, restoring to muted"
+                )
+
+    return {
+        "hide": hide,
+        "restore": restore,
+        "stable": stable,
+        "hide_debug": sorted(hide_debug),
+        "restore_debug": sorted(restore_debug),
+        "stable_debug": sorted(stable_debug),
+        "stats": {"linked_tests": len(latest_close_by_test)},
+    }
+
+
+def build_final_muted_ya_list(
+    base_muted_ya: List[str],
+    to_mute: List[str],
+    to_unmute: Set[str],
+    to_delete: Set[str],
+    quarantine_hide: Set[str],
+    quarantine_restore: Set[str],
+) -> List[str]:
+    overlap = quarantine_hide & quarantine_restore
+    if overlap:
+        raise ValueError(
+            f"Invalid quarantine state: hide/restore overlap for {len(overlap)} tests"
+        )
+
+    base_minus = [
+        name
+        for name in base_muted_ya
+        if name not in to_delete and name not in to_unmute and name not in quarantine_hide
+    ]
+    result = list(base_minus)
+    current = set(base_minus)
+
+    for name in to_mute:
+        if name not in current and name not in quarantine_hide:
+            result.append(name)
+            current.add(name)
+
+    for name in sorted(quarantine_restore):
+        if name not in current:
+            result.append(name)
+            current.add(name)
+
+    hidden_intersection = quarantine_hide & set(result)
+    if hidden_intersection:
+        raise ValueError(
+            f"Invalid final muted_ya: hidden tests leaked into output ({len(hidden_intersection)})"
+        )
+
+    return result
+
+
+def _build_unmute_candidates(
+    aggregated_for_unmute: List[dict],
+    thresholds: Dict[str, int],
+) -> Set[str]:
+    candidates: Set[str] = set()
+    for test in aggregated_for_unmute:
+        full_name = test.get("full_name")
+        if not full_name:
+            continue
+        pass_count = int(test.get("pass_count", 0) or 0)
+        fail_count = int(test.get("fail_count", 0) or 0)
+        mute_count = int(test.get("mute_count", 0) or 0)
+        if passes_default_unmute(pass_count, fail_count, mute_count, thresholds):
+            candidates.add(str(full_name))
+    return candidates
+
+
+def resolve_user_fixed_quarantine_actions(
+    ydb_wrapper,
+    branch: str,
+    build_type: str,
+    all_data: List[dict],
+    aggregated_for_unmute: List[dict],
+    thresholds: Dict[str, int],
+    now_utc: Optional[datetime.datetime] = None,
+) -> Dict[str, object]:
+    merged_thresholds = dict(DEFAULT_THRESHOLDS)
+    merged_thresholds.update({k: int(v) for k, v in dict(thresholds or {}).items()})
+    quarantine_days = int(merged_thresholds["quarantine_user_fixed_window_days"])
+    lookback_days = max(quarantine_days * 3, 30)
+    unmute_candidates = _build_unmute_candidates(aggregated_for_unmute, merged_thresholds)
+
+    try:
+        issues_table = ydb_wrapper.get_table_path("issues")
+    except Exception:
+        out = empty_quarantine_actions()
+        out["stats"] = {"error": "issues_table_path_unavailable"}
+        return out
+
+    query = f"""
+    SELECT issue_number, body, closed_at, closed_by_type
+    FROM `{issues_table}`
+    WHERE state = 'CLOSED'
+      AND closed_at IS NOT NULL
+      AND closed_at >= CurrentUtcTimestamp() - {lookback_days} * Interval("P1D")
+    """
+    try:
+        rows = ydb_wrapper.execute_scan_query(
+            query,
+            query_name=f"user_fixed_quarantine_candidates_{branch}_{build_type}",
+        )
+    except Exception:
+        out = empty_quarantine_actions()
+        out["stats"] = {"error": "issues_query_failed"}
+        return out
+
+    latest_close_by_test, extract_stats = extract_latest_user_closed_tests(
+        rows=rows,
+        branch=branch,
+        build_type=build_type,
+    )
+    full_name_to_mute_strings = build_full_name_to_mute_strings(all_data)
+    actions = compute_user_fixed_quarantine_actions(
+        latest_close_by_test=latest_close_by_test,
+        full_name_to_mute_strings=full_name_to_mute_strings,
+        unmute_candidates=unmute_candidates,
+        quarantine_days=quarantine_days,
+        now_utc=now_utc,
+    )
+    actions["stats"] = {
+        **extract_stats,
+        "actions_hide": len(actions["hide"]),
+        "actions_restore": len(actions["restore"]),
+        "actions_stable": len(actions["stable"]),
+    }
+    return actions
+
+
+def _extract_test_name_from_debug_line(debug_line: str) -> str:
+    return str(debug_line).split(" #", 1)[0]
+
+
+def _filter_debug_lines_by_tests(debug_lines: List[str], allowed_tests: Set[str]) -> List[str]:
+    return [line for line in debug_lines if _extract_test_name_from_debug_line(line) in allowed_tests]
+
+
+def _build_quarantine_debug_map(quarantine_actions: Dict[str, object]) -> Dict[str, str]:
+    result: Dict[str, str] = {}
+    for debug_line in (
+        list(quarantine_actions.get("hide_debug") or [])
+        + list(quarantine_actions.get("restore_debug") or [])
+        + list(quarantine_actions.get("stable_debug") or [])
+    ):
+        test_name = _extract_test_name_from_debug_line(str(debug_line))
+        result[test_name] = str(debug_line)
+    return result
+
+
+def apply_quarantine_actions(
+    to_unmute: List[str],
+    to_delete: List[str],
+    to_unmute_debug: List[str],
+    to_delete_debug: List[str],
+    quarantine_actions: Optional[Dict[str, object]],
+) -> Dict[str, object]:
+    quarantine_actions = quarantine_actions or empty_quarantine_actions()
+    quarantine_hide_set = set(quarantine_actions.get("hide") or set())
+    quarantine_restore_set = set(quarantine_actions.get("restore") or set())
+    quarantine_stable_set = set(quarantine_actions.get("stable") or set())
+    quarantine_debug_map = _build_quarantine_debug_map(quarantine_actions)
+
+    to_unmute_set = set(to_unmute) - quarantine_hide_set
+    to_delete_set = set(to_delete) - quarantine_hide_set
+    filtered_unmute_debug = _filter_debug_lines_by_tests(to_unmute_debug, to_unmute_set)
+    filtered_delete_debug = _filter_debug_lines_by_tests(to_delete_debug, to_delete_set)
+
+    return {
+        "to_unmute": sorted(to_unmute_set),
+        "to_delete": sorted(to_delete_set),
+        "to_unmute_debug": filtered_unmute_debug,
+        "to_delete_debug": filtered_delete_debug,
+        "quarantine_hide_set": quarantine_hide_set,
+        "quarantine_restore_set": quarantine_restore_set,
+        "quarantine_stable_set": quarantine_stable_set,
+        "quarantine_debug_map": quarantine_debug_map,
+    }
+
+
+def finalize_new_muted_ya(
+    all_muted_ya: List[str],
+    to_delete: List[str],
+    to_unmute: List[str],
+    to_mute: List[str],
+    quarantine_hide_set: Set[str],
+    quarantine_restore_set: Set[str],
+) -> List[str]:
+    return build_final_muted_ya_list(
+        base_muted_ya=all_muted_ya,
+        to_mute=to_mute,
+        to_unmute=set(to_unmute),
+        to_delete=set(to_delete),
+        quarantine_hide=quarantine_hide_set,
+        quarantine_restore=quarantine_restore_set,
+    )

--- a/.github/scripts/tests/mute_quarantine.py
+++ b/.github/scripts/tests/mute_quarantine.py
@@ -372,36 +372,3 @@ def finalize_new_muted_ya(
         quarantine_hide=quarantine_hide_set,
         quarantine_restore=quarantine_restore_set,
     )
-
-
-# Backward-compatible aliases for callers that imported the old names during
-# intermediate refactors.
-def latest_user_closed_at_by_test(
-    rows: List[dict],
-    branch: str,
-    build_type: str,
-    parse_body_fn=parse_body,
-    default_build_type: str = DEFAULT_BUILD_TYPE,
-    normalize_utc_datetime_fn=normalize_utc_datetime,
-) -> Dict[str, datetime.datetime]:
-    _ = parse_body_fn
-    _ = default_build_type
-    _ = normalize_utc_datetime_fn
-    latest, _stats = extract_latest_user_closed_tests(rows, branch, build_type)
-    return latest
-
-
-def classify_quarantine_actions_for_closed_tests(
-    latest_close_by_test: Dict[str, datetime.datetime],
-    unmute_candidates: Set[str],
-    full_name_to_mute_strings: Dict[str, Set[str]],
-    quarantine_days: int,
-    fallback_mute_string_fn=fallback_mute_string_from_full_name,
-) -> Dict[str, object]:
-    _ = fallback_mute_string_fn
-    return compute_user_fixed_quarantine_actions(
-        latest_close_by_test=latest_close_by_test,
-        full_name_to_mute_strings=full_name_to_mute_strings,
-        unmute_candidates=unmute_candidates,
-        quarantine_days=quarantine_days,
-    )

--- a/.github/scripts/tests/test_create_new_muted_ya_e2e.py
+++ b/.github/scripts/tests/test_create_new_muted_ya_e2e.py
@@ -1,0 +1,176 @@
+#!/usr/bin/env python3
+import os
+import sys
+import tempfile
+import types
+import unittest
+import logging
+from contextlib import redirect_stdout
+from io import StringIO
+
+
+if "ydb" not in sys.modules:
+    sys.modules["ydb"] = types.ModuleType("ydb")
+if "ydb_wrapper" not in sys.modules:
+    ydb_wrapper_stub = types.ModuleType("ydb_wrapper")
+
+    class _DummyYDBWrapper:  # pragma: no cover - import-time stub only
+        pass
+
+    ydb_wrapper_stub.YDBWrapper = _DummyYDBWrapper
+    sys.modules["ydb_wrapper"] = ydb_wrapper_stub
+
+sys.path.append(os.path.join(os.path.dirname(__file__)))
+import create_new_muted_ya as mute_flow  # noqa: E402
+
+logging.getLogger().setLevel(logging.WARNING)
+
+
+class _FakeMuteCheck:
+    def __init__(self, muted_tests):
+        self._muted_tests = set(muted_tests)
+
+    def __call__(self, suite_name, test_name):
+        return f"{suite_name} {test_name}" in self._muted_tests
+
+
+def _row(
+    suite_folder,
+    test_name,
+    full_name,
+    *,
+    is_muted,
+    pass_count=0,
+    fail_count=0,
+    mute_count=0,
+    skip_count=0,
+    is_test_chunk=0,
+):
+    return {
+        "suite_folder": suite_folder,
+        "test_name": test_name,
+        "full_name": full_name,
+        "owner": "ci",
+        "is_muted": is_muted,
+        "pass_count": pass_count,
+        "fail_count": fail_count,
+        "mute_count": mute_count,
+        "skip_count": skip_count,
+        "is_test_chunk": is_test_chunk,
+        "period_days": 7,
+        "date_window": "2026-04-17",
+        "state": "MUTED" if is_muted else "FLAKY",
+    }
+
+
+def _read_lines(path):
+    with open(path, "r", encoding="utf-8") as fh:
+        return [line.strip() for line in fh if line.strip()]
+
+
+class TestCreateNewMutedYaE2E(unittest.TestCase):
+    def test_generates_consistent_artifacts_with_quarantine_actions(self):
+        suite = "ydb/tests/suite"
+
+        test_hidden = _row(
+            suite,
+            "test_hidden",
+            "ydb/tests/suite/test_hidden",
+            is_muted=True,
+            pass_count=8,
+            fail_count=0,
+            mute_count=0,
+        )
+        test_delete = _row(
+            suite,
+            "test_delete",
+            "ydb/tests/suite/test_delete",
+            is_muted=True,
+            pass_count=0,
+            fail_count=0,
+            mute_count=0,
+            skip_count=0,
+        )
+        test_stays_muted = _row(
+            suite,
+            "test_stays_muted",
+            "ydb/tests/suite/test_stays_muted",
+            is_muted=True,
+            pass_count=1,
+            fail_count=1,
+            mute_count=2,
+        )
+        test_new_mute = _row(
+            suite,
+            "test_new_mute",
+            "ydb/tests/suite/test_new_mute",
+            is_muted=False,
+            pass_count=0,
+            fail_count=2,
+            mute_count=0,
+        )
+
+        all_data = [test_hidden, test_delete, test_stays_muted, test_new_mute]
+        aggregated_for_mute = [test_hidden, test_delete, test_stays_muted, test_new_mute]
+        aggregated_for_unmute = [test_hidden, test_stays_muted]
+        aggregated_for_delete = [test_hidden, test_delete, test_stays_muted]
+
+        muted_rows = {
+            f"{suite} test_hidden",
+            f"{suite} test_delete",
+            f"{suite} test_stays_muted",
+        }
+        mute_check = _FakeMuteCheck(muted_rows)
+
+        quarantine_actions = {
+            "hide": {f"{suite} test_hidden"},
+            "restore": {f"{suite} test_restored"},
+            "stable": set(),
+            "hide_debug": [f"{suite} test_hidden # quarantine_user_fixed active"],
+            "restore_debug": [f"{suite} test_restored # quarantine_user_fixed expired"],
+            "stable_debug": [],
+            "stats": {},
+        }
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            # The production function prints progress bars to stdout.
+            # Keep test output deterministic and compact.
+            with redirect_stdout(StringIO()):
+                muted_count = mute_flow.apply_and_add_mutes(
+                    all_data=all_data,
+                    output_path=tmpdir,
+                    mute_check=mute_check,
+                    aggregated_for_mute=aggregated_for_mute,
+                    aggregated_for_unmute=aggregated_for_unmute,
+                    aggregated_for_delete=aggregated_for_delete,
+                    quarantine_actions=quarantine_actions,
+                )
+            self.assertEqual(muted_count, 1)
+
+            update_dir = os.path.join(tmpdir, "mute_update")
+            new_muted_ya = _read_lines(os.path.join(update_dir, "new_muted_ya.txt"))
+            to_unmute = _read_lines(os.path.join(update_dir, "to_unmute.txt"))
+            to_delete = _read_lines(os.path.join(update_dir, "to_delete.txt"))
+            quarantine_hidden = _read_lines(os.path.join(update_dir, "quarantine_hidden.txt"))
+            quarantine_restored = _read_lines(os.path.join(update_dir, "quarantine_restored.txt"))
+            changes = _read_lines(os.path.join(update_dir, "muted_ya_changes.txt"))
+
+            self.assertNotIn(f"{suite} test_hidden", new_muted_ya)
+            self.assertNotIn(f"{suite} test_delete", new_muted_ya)
+            self.assertIn(f"{suite} test_stays_muted", new_muted_ya)
+            self.assertIn(f"{suite} test_new_mute", new_muted_ya)
+            self.assertIn(f"{suite} test_restored", new_muted_ya)
+
+            self.assertNotIn(f"{suite} test_hidden", to_unmute)
+            self.assertIn(f"{suite} test_delete", to_delete)
+            self.assertEqual(quarantine_hidden, [f"{suite} test_hidden"])
+            self.assertEqual(quarantine_restored, [f"{suite} test_restored"])
+
+            self.assertIn(f"--- {suite} test_hidden", changes)
+            self.assertIn(f"xxx {suite} test_delete", changes)
+            self.assertIn(f"+++ {suite} test_new_mute", changes)
+            self.assertIn(f"+++ {suite} test_restored", changes)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.github/scripts/tests/test_mute_policy_rules.py
+++ b/.github/scripts/tests/test_mute_policy_rules.py
@@ -1,0 +1,46 @@
+#!/usr/bin/env python3
+import os
+import sys
+import unittest
+
+
+sys.path.append(os.path.join(os.path.dirname(__file__), ".."))
+from mute_policy_rules import (  # noqa: E402
+    DEFAULT_THRESHOLDS,
+    is_delete_candidate_counts,
+    passes_default_mute,
+    passes_default_unmute,
+)
+
+
+class TestMutePolicyRules(unittest.TestCase):
+    def test_passes_default_mute_low_volume(self):
+        self.assertTrue(passes_default_mute(pass_count=1, fail_count=2, thresholds=DEFAULT_THRESHOLDS))
+
+    def test_passes_default_mute_high_volume(self):
+        self.assertTrue(passes_default_mute(pass_count=20, fail_count=3, thresholds=DEFAULT_THRESHOLDS))
+
+    def test_passes_default_unmute(self):
+        self.assertTrue(
+            passes_default_unmute(
+                pass_count=4,
+                fail_count=0,
+                mute_count=0,
+                thresholds=DEFAULT_THRESHOLDS,
+            )
+        )
+
+    def test_delete_candidate_for_skipped_muted_test(self):
+        self.assertTrue(
+            is_delete_candidate_counts(
+                pass_count=0,
+                fail_count=0,
+                mute_count=0,
+                skip_count=2,
+                is_muted=True,
+            )
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.github/scripts/tests/test_mute_quarantine.py
+++ b/.github/scripts/tests/test_mute_quarantine.py
@@ -110,6 +110,7 @@ class TestMuteQuarantine(unittest.TestCase):
         self.assertEqual(actions["hide"], set())
         self.assertEqual(actions["restore"], set())
         self.assertEqual(actions["stable"], set())
+        self.assertEqual(actions.get("stats", {}).get("error"), "issues_table_path_unavailable")
 
     def test_returns_empty_actions_on_query_error(self):
         wrapper = _StubYdbWrapper(query_error=RuntimeError("query failed"))
@@ -124,7 +125,37 @@ class TestMuteQuarantine(unittest.TestCase):
         self.assertEqual(actions["hide"], set())
         self.assertEqual(actions["restore"], set())
         self.assertEqual(actions["stable"], set())
-        self.assertIn("error", actions.get("stats", {}))
+        self.assertEqual(actions.get("stats", {}).get("error"), "issues_query_failed")
+
+    def test_rejects_user_closed_not_planned_for_quarantine(self):
+        rows = [
+            {
+                "body": (
+                    "Mute:<!--mute_list_start-->\n"
+                    "ydb/tests/suite/test_a\n"
+                    "<!--mute_list_end-->\n\n"
+                    "Branch:<!--branch_list_start-->\nmain\n<!--branch_list_end-->\n\n"
+                    "Build type:<!--build_type_list_start-->\nrelwithdebinfo\n<!--build_type_list_end-->\n"
+                ),
+                "closed_by_type": "User",
+                "state_reason": "NOT_PLANNED",
+                "closed_at": self.base_now - datetime.timedelta(days=2),
+            }
+        ]
+        wrapper = _StubYdbWrapper(rows=rows)
+        actions = mq.resolve_user_fixed_quarantine_actions(
+            ydb_wrapper=wrapper,
+            branch="main",
+            build_type="relwithdebinfo",
+            all_data=self.all_data,
+            aggregated_for_unmute=self.aggregated_for_unmute,
+            thresholds=self.thresholds,
+            now_utc=self.base_now,
+        )
+        self.assertEqual(actions["hide"], set())
+        self.assertEqual(actions["restore"], set())
+        self.assertEqual(actions["stable"], set())
+        self.assertEqual(actions.get("stats", {}).get("rows_state_reason_rejected"), 1)
 
     def test_apply_quarantine_actions_updates_sets_and_debug(self):
         to_unmute = ["a", "b", "c"]

--- a/.github/scripts/tests/test_mute_quarantine.py
+++ b/.github/scripts/tests/test_mute_quarantine.py
@@ -1,0 +1,177 @@
+#!/usr/bin/env python3
+import datetime
+import os
+import sys
+import unittest
+
+
+sys.path.append(os.path.join(os.path.dirname(__file__)))
+import mute_quarantine as mq  # noqa: E402
+
+
+class _StubYdbWrapper:
+    def __init__(self, table_path="test_results/analytics/issues", rows=None, path_error=None, query_error=None):
+        self._table_path = table_path
+        self._rows = rows or []
+        self._path_error = path_error
+        self._query_error = query_error
+
+    def get_table_path(self, table_name):
+        if self._path_error:
+            raise self._path_error
+        return self._table_path
+
+    def execute_scan_query(self, query, query_name=None):
+        _ = query
+        _ = query_name
+        if self._query_error:
+            raise self._query_error
+        return self._rows
+
+
+class TestMuteQuarantine(unittest.TestCase):
+    def setUp(self):
+        self.thresholds = {"quarantine_user_fixed_window_days": 7}
+        self.base_now = datetime.datetime(2026, 4, 21, 12, 0, 0, tzinfo=datetime.timezone.utc)
+        self.all_data = [
+            {"full_name": "ydb/tests/suite/test_a", "suite_folder": "ydb/tests/suite", "test_name": "test_a"},
+            {"full_name": "ydb/tests/suite/test_b", "suite_folder": "ydb/tests/suite", "test_name": "test_b"},
+            {"full_name": "ydb/tests/suite/test_c", "suite_folder": "ydb/tests/suite", "test_name": "test_c"},
+        ]
+        self.aggregated_for_unmute = [
+            {"full_name": "ydb/tests/suite/test_b", "pass_count": 10, "fail_count": 0, "mute_count": 0}
+        ]
+
+    def test_classifies_hide_restore_stable_by_quarantine_age(self):
+        rows = [
+            {
+                "body": (
+                    "Mute:<!--mute_list_start-->\n"
+                    "ydb/tests/suite/test_a\n"
+                    "<!--mute_list_end-->\n\n"
+                    "Branch:<!--branch_list_start-->\nmain\n<!--branch_list_end-->\n\n"
+                    "Build type:<!--build_type_list_start-->\nrelwithdebinfo\n<!--build_type_list_end-->\n"
+                ),
+                "closed_by_type": "User",
+                "closed_at": self.base_now - datetime.timedelta(days=2),
+            },
+            {
+                "body": (
+                    "Mute:<!--mute_list_start-->\n"
+                    "ydb/tests/suite/test_b\n"
+                    "<!--mute_list_end-->\n\n"
+                    "Branch:<!--branch_list_start-->\nmain\n<!--branch_list_end-->\n\n"
+                    "Build type:<!--build_type_list_start-->\nrelwithdebinfo\n<!--build_type_list_end-->\n"
+                ),
+                "closed_by_type": "User",
+                "closed_at": self.base_now - datetime.timedelta(days=9),
+            },
+            {
+                "body": (
+                    "Mute:<!--mute_list_start-->\n"
+                    "ydb/tests/suite/test_c\n"
+                    "<!--mute_list_end-->\n\n"
+                    "Branch:<!--branch_list_start-->\nmain\n<!--branch_list_end-->\n\n"
+                    "Build type:<!--build_type_list_start-->\nrelwithdebinfo\n<!--build_type_list_end-->\n"
+                ),
+                "closed_by_type": "User",
+                "closed_at": self.base_now - datetime.timedelta(days=9),
+            },
+        ]
+        wrapper = _StubYdbWrapper(rows=rows)
+
+        actions = mq.resolve_user_fixed_quarantine_actions(
+            ydb_wrapper=wrapper,
+            branch="main",
+            build_type="relwithdebinfo",
+            all_data=self.all_data,
+            aggregated_for_unmute=self.aggregated_for_unmute,
+            thresholds=self.thresholds,
+            now_utc=self.base_now,
+        )
+
+        self.assertEqual(actions["hide"], {"ydb/tests/suite test_a"})
+        self.assertEqual(actions["stable"], {"ydb/tests/suite test_b"})
+        self.assertEqual(actions["restore"], {"ydb/tests/suite test_c"})
+        self.assertTrue(any("active" in line for line in actions["hide_debug"]))
+        self.assertTrue(any("passed" in line for line in actions["stable_debug"]))
+        self.assertTrue(any("expired" in line for line in actions["restore_debug"]))
+
+    def test_returns_empty_actions_when_table_path_missing(self):
+        wrapper = _StubYdbWrapper(path_error=KeyError("issues table missing"))
+        actions = mq.resolve_user_fixed_quarantine_actions(
+            ydb_wrapper=wrapper,
+            branch="main",
+            build_type="relwithdebinfo",
+            all_data=self.all_data,
+            aggregated_for_unmute=self.aggregated_for_unmute,
+            thresholds=self.thresholds,
+        )
+        self.assertEqual(actions["hide"], set())
+        self.assertEqual(actions["restore"], set())
+        self.assertEqual(actions["stable"], set())
+
+    def test_returns_empty_actions_on_query_error(self):
+        wrapper = _StubYdbWrapper(query_error=RuntimeError("query failed"))
+        actions = mq.resolve_user_fixed_quarantine_actions(
+            ydb_wrapper=wrapper,
+            branch="main",
+            build_type="relwithdebinfo",
+            all_data=self.all_data,
+            aggregated_for_unmute=self.aggregated_for_unmute,
+            thresholds=self.thresholds,
+        )
+        self.assertEqual(actions["hide"], set())
+        self.assertEqual(actions["restore"], set())
+        self.assertEqual(actions["stable"], set())
+        self.assertIn("error", actions.get("stats", {}))
+
+    def test_apply_quarantine_actions_updates_sets_and_debug(self):
+        to_unmute = ["a", "b", "c"]
+        to_delete = ["a", "b", "d"]
+        to_unmute_debug = ["a # keep", "b # keep", "c # keep"]
+        to_delete_debug = ["a # keep", "b # keep", "d # keep"]
+        actions = {
+            "hide": {"a"},
+            "restore": {"x"},
+            "stable": {"b"},
+            "hide_debug": ["a # hidden"],
+            "restore_debug": ["x # restored"],
+            "stable_debug": ["b # stable"],
+        }
+
+        updated = mq.apply_quarantine_actions(to_unmute, to_delete, to_unmute_debug, to_delete_debug, actions)
+
+        self.assertEqual(updated["to_unmute"], ["b", "c"])
+        self.assertEqual(updated["to_delete"], ["b", "d"])
+        self.assertEqual(updated["to_unmute_debug"], ["b # keep", "c # keep"])
+        self.assertEqual(updated["to_delete_debug"], ["b # keep", "d # keep"])
+        self.assertEqual(updated["quarantine_hide_set"], {"a"})
+        self.assertEqual(updated["quarantine_restore_set"], {"x"})
+        self.assertIn("a", updated["quarantine_debug_map"])
+        self.assertIn("x", updated["quarantine_debug_map"])
+
+    def test_finalize_new_muted_ya_invariants(self):
+        all_muted_ya = ["a", "b", "c"]
+        to_delete = ["b"]
+        to_unmute = ["c"]
+        to_mute = ["d"]
+        quarantine_hide_set = {"a"}
+        quarantine_restore_set = {"x"}
+
+        final_tests = mq.build_final_muted_ya_list(
+            base_muted_ya=all_muted_ya,
+            to_delete=set(to_delete),
+            to_unmute=set(to_unmute),
+            to_mute=to_mute,
+            quarantine_hide=quarantine_hide_set,
+            quarantine_restore=quarantine_restore_set,
+        )
+
+        self.assertNotIn("a", final_tests)
+        self.assertIn("x", final_tests)
+        self.assertIn("d", final_tests)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Simplified and hardened mute quarantine flow, added e2e coverage for mute artifact generation, and refreshed mute rules documentation in a human-friendly English format with explicit time windows.

### Changelog category <!-- remove all except one -->

* Improvement

### Description for reviewers <!-- (optional) description for those who read this PR -->

This branch now contains:

1. Quarantine logic modularization and deduplication (`mute_quarantine.py` + orchestrator cleanup).
2. Fail-safe observability for quarantine (`issues_table_path_unavailable`, `issues_query_failed`) with stats logging.
3. Filtering of user-fixed signal by closure reason (`state_reason == COMPLETED`).
4. Unit-test expansion for quarantine behavior and fail-safe cases.
5. Fixture-based e2e test (`test_create_new_muted_ya_e2e.py`) that validates generated mute artifacts and final-list invariants.
6. Final API cleanup: removed temporary compatibility aliases from `mute_quarantine.py`.
7. Documentation update requested by maintainers:
   - `.github/config/mute_rules.md` is now in English,
   - starts with explicit human-facing blocks: **MUTE when** and **UNMUTE when**,
   - includes a dedicated **Time windows** block (mute/unmute/delete/quarantine),
   - keeps behavior and file names aligned with current automation.

#### Validation

- `python3 -m py_compile .github/scripts/tests/create_new_muted_ya.py .github/scripts/tests/mute_quarantine.py .github/scripts/tests/test_mute_quarantine.py .github/scripts/tests/test_mute_policy_rules.py .github/scripts/tests/test_create_new_muted_ya_e2e.py`
- `python3 .github/scripts/tests/test_mute_policy_rules.py`
- `python3 .github/scripts/tests/test_mute_quarantine.py`
- `python3 .github/scripts/tests/test_create_new_muted_ya_e2e.py`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ecc1264e-c283-49e2-a016-5a4640e6eeea"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ecc1264e-c283-49e2-a016-5a4640e6eeea"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

