### PR TITLE
fix(mute): keep CLOSED+COMPLETED mute issues in project index

### DIFF
--- a/.github/scripts/analytics/data_mart_queries/muted_tests_with_issue_and_area.sql
+++ b/.github/scripts/analytics/data_mart_queries/muted_tests_with_issue_and_area.sql
@@ -29,9 +29,11 @@ $gim_latest = (
         github_issue_url AS github_issue_url,
         github_issue_number AS github_issue_number,
         github_issue_state AS github_issue_state,
+        github_issue_state_reason AS github_issue_state_reason,
         github_issue_created_at AS github_issue_created_at,
         area_override AS area_override,
-        area_override_since AS area_override_since
+        area_override_since AS area_override_since,
+        info AS github_issue_info
     FROM (
         SELECT
             g.full_name AS full_name,
@@ -40,9 +42,11 @@ $gim_latest = (
             g.github_issue_url AS github_issue_url,
             g.github_issue_number AS github_issue_number,
             g.github_issue_state AS github_issue_state,
+            g.github_issue_state_reason AS github_issue_state_reason,
             g.github_issue_created_at AS github_issue_created_at,
             g.area_override AS area_override,
             g.area_override_since AS area_override_since,
+            g.info AS info,
             ROW_NUMBER() OVER (
                 PARTITION BY g.full_name, g.branch, g.build_type
                 ORDER BY g.github_issue_created_at DESC, g.github_issue_number DESC
@@ -100,9 +104,11 @@ SELECT
     gim.github_issue_url AS github_issue_url,
     gim.github_issue_number AS github_issue_number,
     gim.github_issue_state AS github_issue_state,
+    gim.github_issue_state_reason AS github_issue_state_reason,
     gim.github_issue_created_at AS github_issue_created_at,
     gim.area_override AS area_override,
     gim.area_override_since AS area_override_since,
+    gim.github_issue_info AS github_issue_info,
     CAST(CASE WHEN mfu.full_name IS NOT NULL THEN 1 ELSE 0 END AS Uint8) AS is_manual_fast_unmute,
     mfu.mfu_since AS manual_fast_unmute_since,
     mfu.mfu_window_days AS manual_fast_unmute_window_days,

--- a/.github/scripts/analytics/data_mart_queries/test_muted_monitor_mart_with_issue.sql
+++ b/.github/scripts/analytics/data_mart_queries/test_muted_monitor_mart_with_issue.sql
@@ -36,9 +36,11 @@ $gim_latest = (
         github_issue_url AS github_issue_url,
         github_issue_number AS github_issue_number,
         github_issue_state AS github_issue_state,
+        github_issue_state_reason AS github_issue_state_reason,
         github_issue_created_at AS github_issue_created_at,
         area_override AS area_override,
-        area_override_since AS area_override_since
+        area_override_since AS area_override_since,
+        info AS github_issue_info
     FROM (
         SELECT
             g.full_name AS full_name,
@@ -47,9 +49,11 @@ $gim_latest = (
             g.github_issue_url AS github_issue_url,
             g.github_issue_number AS github_issue_number,
             g.github_issue_state AS github_issue_state,
+            g.github_issue_state_reason AS github_issue_state_reason,
             g.github_issue_created_at AS github_issue_created_at,
             g.area_override AS area_override,
             g.area_override_since AS area_override_since,
+            g.info AS info,
             ROW_NUMBER() OVER (
                 PARTITION BY g.full_name, g.branch, g.build_type
                 ORDER BY g.github_issue_created_at DESC, g.github_issue_number DESC
@@ -119,9 +123,11 @@ SELECT
     gim.github_issue_url AS github_issue_url,
     gim.github_issue_number AS github_issue_number,
     gim.github_issue_state AS github_issue_state,
+    gim.github_issue_state_reason AS github_issue_state_reason,
     gim.github_issue_created_at AS github_issue_created_at,
     gim.area_override AS area_override,
     gim.area_override_since AS area_override_since,
+    gim.github_issue_info AS github_issue_info,
     CAST(CASE WHEN mfu.full_name IS NOT NULL THEN 1 ELSE 0 END AS Uint8) AS is_manual_fast_unmute,
     mfu.mfu_since AS manual_fast_unmute_since,
     mfu.mfu_window_days AS manual_fast_unmute_window_days,

--- a/.github/scripts/analytics/github_issue_mapping.py
+++ b/.github/scripts/analytics/github_issue_mapping.py
@@ -232,11 +232,19 @@ def _resolve_area_to_team(area_label: str, area_to_owner: dict) -> str:
     return best_team
 
 
-def resolve_area_override(body: str, info_raw, area_to_owner: dict):
+def resolve_area_override(body: str, info_raw, area_to_owner: dict, issue_state=None):
     """If GitHub ``area/...`` implies a different team than ``Owner:``, return that area path.
 
     Stored value matches issue info (e.g. ``area/blobstorage``), not the resolved team slug.
+
+    **Closed issues** never contribute an override: after automation unmutes (routine close or
+    fast-track completion) the mute issue is closed — routing falls back to TESTOWNERS until a
+    new open mute issue with ``area/`` applies again.
     """
+    st = (issue_state or "").strip().upper()
+    if st == "CLOSED":
+        return None
+
     area_label = (_extract_area_from_info(info_raw) or "").strip()
     if not area_label:
         return None
@@ -377,6 +385,7 @@ def main():
                         issue.get('body', ''),
                         issue.get('info'),
                         area_to_owner,
+                        issue.get('state'),
                     )
 
             print("Creating test-to-issue mapping...")

--- a/.github/scripts/analytics/github_issue_mapping.py
+++ b/.github/scripts/analytics/github_issue_mapping.py
@@ -15,6 +15,9 @@ row; downstream marts use those columns.
 
 Edge cases:
   * No ``area`` in issue ``info`` → area_override = NULL
+  * Closed **NOT_PLANNED** / **DUPLICATE** → area_override = NULL
+  * Closed **COMPLETED** with ``manual-fast-unmute`` label → override applies (fast-track window)
+  * Closed **COMPLETED** without that label → override cleared if **project Status** is ``Unmuted`` or closer is automation bot
   * Area resolves to the same team as the default owner → area_override = NULL
   * Area not found in mapping → area_override = NULL
   * Labels change → we always see the *current* ``info`` snapshot
@@ -47,8 +50,10 @@ from ydb_wrapper import YDBWrapper
 
 sys.path.append(os.path.join(os.path.dirname(__file__), '..'))
 from github_issue_utils import (
+    MANUAL_FAST_UNMUTE_GITHUB_LABEL,
     create_test_issue_mapping,
     DEFAULT_BUILD_TYPE,
+    issue_label_names_lower,
     scan_to_utc_date,
 )
 
@@ -216,6 +221,22 @@ def _extract_area_from_info(info_raw) -> str:
     return info.get("area") or ""
 
 
+def _closed_by_login_lower(info_raw) -> str:
+    """``issues.info`` JSON → ``closed_by_login`` lowercased (who closed the issue)."""
+    if not info_raw:
+        return ""
+    try:
+        if isinstance(info_raw, str):
+            info = json.loads(info_raw) if info_raw.strip() else {}
+        elif isinstance(info_raw, dict):
+            info = info_raw
+        else:
+            info = json.loads(str(info_raw))
+    except (json.JSONDecodeError, TypeError):
+        return ""
+    return (info.get("closed_by_login") or "").strip().lower()
+
+
 def _resolve_area_to_team(area_label: str, area_to_owner: dict) -> str:
     """Prefix match: area/cs/compression -> area/cs (longest mapping key wins).
 
@@ -232,18 +253,47 @@ def _resolve_area_to_team(area_label: str, area_to_owner: dict) -> str:
     return best_team
 
 
-def resolve_area_override(body: str, info_raw, area_to_owner: dict, issue_state=None):
+def resolve_area_override(
+    body: str,
+    info_raw,
+    area_to_owner: dict,
+    issue_state=None,
+    state_reason=None,
+    labels_raw=None,
+    project_status=None,
+):
     """If GitHub ``area/...`` implies a different team than ``Owner:``, return that area path.
 
-    Stored value matches issue info (e.g. ``area/blobstorage``), not the resolved team slug.
+    **Closed issues**
 
-    **Closed issues** never contribute an override: after automation unmutes (routine close or
-    fast-track completion) the mute issue is closed — routing falls back to TESTOWNERS until a
-    new open mute issue with ``area/`` applies again.
+    * ``NOT_PLANNED`` / ``DUPLICATE``: no override (row may still appear before exclusion filters).
+    * ``COMPLETED`` + label ``manual-fast-unmute``: override stays (fast-track active after human complete).
+    * ``COMPLETED`` without that label: override cleared when **project Status** is ``Unmuted`` (fast-track
+      success), or when closed by automation (``ydbot``, ``github-actions``, ``*[bot]``) — routine unmute;
+      otherwise kept (e.g. human closed completed without entering fast-track).
+
+    Open issues: unchanged area logic.
     """
     st = (issue_state or "").strip().upper()
+    sr = (state_reason or "").strip().upper()
+    labels_lo = issue_label_names_lower(labels_raw)
+
     if st == "CLOSED":
-        return None
+        if sr in ("NOT_PLANNED", "DUPLICATE"):
+            return None
+        if sr == "COMPLETED":
+            if MANUAL_FAST_UNMUTE_GITHUB_LABEL.lower() in labels_lo:
+                pass
+            else:
+                ps = (project_status or "").strip().lower()
+                if ps == "unmuted":
+                    return None
+                closer = _closed_by_login_lower(info_raw)
+                bot_like = closer in ("ydbot", "github-actions") or closer.endswith("[bot]")
+                if bot_like:
+                    return None
+        else:
+            return None
 
     area_label = (_extract_area_from_info(info_raw) or "").strip()
     if not area_label:
@@ -386,6 +436,9 @@ def main():
                         issue.get('info'),
                         area_to_owner,
                         issue.get('state'),
+                        issue.get('state_reason'),
+                        issue.get('labels'),
+                        issue.get('project_status'),
                     )
 
             print("Creating test-to-issue mapping...")

--- a/.github/scripts/analytics/github_issue_mapping.py
+++ b/.github/scripts/analytics/github_issue_mapping.py
@@ -17,7 +17,8 @@ Edge cases:
   * No ``area`` in issue ``info`` → area_override = NULL
   * Closed **NOT_PLANNED** / **DUPLICATE** → area_override = NULL
   * Closed **COMPLETED** with ``manual-fast-unmute`` label → override applies (fast-track window)
-  * Closed **COMPLETED** without that label → override cleared if **project Status** is ``Unmuted`` or closer is automation bot
+  * Closed **COMPLETED** without ``manual-fast-unmute``: override cleared **only** when **project Status**
+    is ``Unmuted`` (do not use closer/bot heuristics — avoids clearing during the gap before the label runs).
   * Area resolves to the same team as the default owner → area_override = NULL
   * Area not found in mapping → area_override = NULL
   * Labels change → we always see the *current* ``info`` snapshot
@@ -221,22 +222,6 @@ def _extract_area_from_info(info_raw) -> str:
     return info.get("area") or ""
 
 
-def _closed_by_login_lower(info_raw) -> str:
-    """``issues.info`` JSON → ``closed_by_login`` lowercased (who closed the issue)."""
-    if not info_raw:
-        return ""
-    try:
-        if isinstance(info_raw, str):
-            info = json.loads(info_raw) if info_raw.strip() else {}
-        elif isinstance(info_raw, dict):
-            info = info_raw
-        else:
-            info = json.loads(str(info_raw))
-    except (json.JSONDecodeError, TypeError):
-        return ""
-    return (info.get("closed_by_login") or "").strip().lower()
-
-
 def _resolve_area_to_team(area_label: str, area_to_owner: dict) -> str:
     """Prefix match: area/cs/compression -> area/cs (longest mapping key wins).
 
@@ -267,10 +252,11 @@ def resolve_area_override(
     **Closed issues**
 
     * ``NOT_PLANNED`` / ``DUPLICATE``: no override (row may still appear before exclusion filters).
-    * ``COMPLETED`` + label ``manual-fast-unmute``: override stays (fast-track active after human complete).
-    * ``COMPLETED`` without that label: override cleared when **project Status** is ``Unmuted`` (fast-track
-      success), or when closed by automation (``ydbot``, ``github-actions``, ``*[bot]``) — routine unmute;
-      otherwise kept (e.g. human closed completed without entering fast-track).
+    * ``COMPLETED`` + label ``manual-fast-unmute``: override stays (fast-track active).
+    * ``COMPLETED`` without that label: override cleared **only** when **project Status** is ``Unmuted``
+      (routine bot unmute and successful fast-track completion both move the board here). We do **not**
+      infer removal from ``closed_by`` alone — human Completed can lag before automation adds the fast-track
+      label, and must keep override until then.
 
     Open issues: unchanged area logic.
     """
@@ -287,10 +273,6 @@ def resolve_area_override(
             else:
                 ps = (project_status or "").strip().lower()
                 if ps == "unmuted":
-                    return None
-                closer = _closed_by_login_lower(info_raw)
-                bot_like = closer in ("ydbot", "github-actions") or closer.endswith("[bot]")
-                if bot_like:
                     return None
         else:
             return None

--- a/.github/scripts/analytics/github_issue_mapping.py
+++ b/.github/scripts/analytics/github_issue_mapping.py
@@ -26,6 +26,14 @@ First ``date_window`` for which datamarts apply ``area_override``. Set from the 
 unchanged override keeps the stored date. ``NULL`` on ``area_override_since`` means there is
 no lower bound: override applies for every ``date_window`` in the mart query (same as omitting
 the check in SQL).
+
+``github_issue_state_reason`` / ``info`` (Json)
+------------------------------------------------
+GitHub close reason (``COMPLETED``, ``NOT_PLANNED``, …) and a JSON snapshot with assignees,
+labels, milestone, project fields, and the export ``info`` blob — see
+:func:`github_issue_utils.build_github_issue_mapping_info_snapshot`.
+
+Add these columns in YDB manually (``ALTER TABLE``); ``CREATE TABLE`` below is for new installs only.
 """
 
 import datetime as dt
@@ -63,7 +71,17 @@ def get_github_issues_data(ydb_wrapper):
         body,
         created_at,
         updated_at,
-        info
+        info,
+        assignees,
+        labels,
+        milestone,
+        project_fields,
+        issue_type,
+        author_login,
+        repository_name,
+        project_status,
+        project_owner,
+        project_priority
     FROM `{issues_table}`
     WHERE body IS NOT NULL
     AND body != ''
@@ -247,10 +265,12 @@ def create_test_issue_mapping_table(ydb_wrapper, table_path):
         `github_issue_url`        Utf8,
         `github_issue_title`      Utf8,
         `github_issue_number`     Uint64     NOT NULL,
-        `github_issue_state`      Utf8,
-        `github_issue_created_at` Timestamp,
-        `area_override`           Utf8,
-        `area_override_since`     Date,
+        `github_issue_state`        Utf8,
+        `github_issue_state_reason` Utf8,
+        `github_issue_created_at`   Timestamp,
+        `area_override`             Utf8,
+        `area_override_since`       Date,
+        `info`                      Json,
         PRIMARY KEY (full_name, branch, build_type, github_issue_number)
     )
     PARTITION BY HASH(full_name)
@@ -279,6 +299,11 @@ def convert_mapping_to_table_data(test_to_issue_mapping):
                 by_build_type[bt] = issue
 
         for bt, latest_issue in by_build_type.items():
+            snap = dict(latest_issue.get('mapping_info') or {})
+            ao = latest_issue.get('area_override')
+            if ao:
+                snap['area_override'] = ao
+            info_json = json.dumps(snap, ensure_ascii=False)
             for branch in latest_issue['branches']:
                 table_data.append({
                     'full_name': test_name,
@@ -288,8 +313,10 @@ def convert_mapping_to_table_data(test_to_issue_mapping):
                     'github_issue_title': latest_issue['title'],
                     'github_issue_number': latest_issue['issue_number'],
                     'github_issue_state': latest_issue['state'],
+                    'github_issue_state_reason': latest_issue.get('state_reason'),
                     'github_issue_created_at': latest_issue.get('created_at'),
                     'area_override': latest_issue.get('area_override'),
+                    'info': info_json,
                 })
 
     return table_data
@@ -307,9 +334,13 @@ def bulk_upsert_mapping_data(ydb_wrapper, table_path, mapping_data):
     column_types.add_column('github_issue_title', ydb.OptionalType(ydb.PrimitiveType.Utf8))
     column_types.add_column('github_issue_number', ydb.PrimitiveType.Uint64)
     column_types.add_column('github_issue_state', ydb.OptionalType(ydb.PrimitiveType.Utf8))
+    column_types.add_column(
+        'github_issue_state_reason', ydb.OptionalType(ydb.PrimitiveType.Utf8)
+    )
     column_types.add_column('github_issue_created_at', ydb.OptionalType(ydb.PrimitiveType.Timestamp))
     column_types.add_column('area_override', ydb.OptionalType(ydb.PrimitiveType.Utf8))
     column_types.add_column('area_override_since', ydb.OptionalType(ydb.PrimitiveType.Date))
+    column_types.add_column('info', ydb.OptionalType(ydb.PrimitiveType.Json))
 
     ydb_wrapper.bulk_upsert(table_path, mapping_data, column_types)
     print(f"Bulk upsert completed")

--- a/.github/scripts/analytics/github_issue_mapping.py
+++ b/.github/scripts/analytics/github_issue_mapping.py
@@ -46,7 +46,12 @@ from github_issue_utils import (
 
 
 def get_github_issues_data(ydb_wrapper):
-    """Get GitHub issues data from the issues table, including labels info."""
+    """Get GitHub issues data from the issues table, including labels info.
+
+    Excludes issues closed as **Not planned** or **Duplicate**: those must not win
+    ``latest per build_type`` in :func:`convert_mapping_to_table_data` or override
+    owner/area from a still-relevant mute issue.
+    """
     issues_table = ydb_wrapper.get_table_path("issues")
     query = f"""
     SELECT
@@ -54,6 +59,7 @@ def get_github_issues_data(ydb_wrapper):
         title,
         url,
         state,
+        state_reason,
         body,
         created_at,
         updated_at,
@@ -61,6 +67,10 @@ def get_github_issues_data(ydb_wrapper):
     FROM `{issues_table}`
     WHERE body IS NOT NULL
     AND body != ''
+    AND NOT (
+        state = 'CLOSED'
+        AND state_reason IN ('NOT_PLANNED', 'DUPLICATE')
+    )
     """
 
     print("Fetching GitHub issues data...")
@@ -259,7 +269,8 @@ def convert_mapping_to_table_data(test_to_issue_mapping):
         if not issues:
             continue
 
-        # Group issues by build_type, then pick the latest per group
+        # Group issues by build_type, then pick the latest created issue per group.
+        # Issues closed as not-planned/duplicate are omitted upstream (get_github_issues_data).
         by_build_type = {}
         for issue in issues:
             bt = issue.get('build_type', DEFAULT_BUILD_TYPE)

--- a/.github/scripts/github_issue_utils.py
+++ b/.github/scripts/github_issue_utils.py
@@ -30,6 +30,9 @@ def team_slug_from_monitor_owner(owner) -> str:
 DEFAULT_BUILD_TYPE = 'relwithdebinfo'
 DEFAULT_BRANCH = 'main'
 
+# Same label as ``mute.update_mute_issues`` / ``mute.fast_unmute_github`` — fast-unmute tracking.
+MANUAL_FAST_UNMUTE_GITHUB_LABEL = 'manual-fast-unmute'
+
 
 def scan_to_utc_date(val) -> Optional[dt.date]:
     """YDB scan value → UTC calendar date.
@@ -252,6 +255,20 @@ def _decode_issues_json_column(val):
         except json.JSONDecodeError:
             return None
     return None
+
+
+def issue_label_names_lower(raw_labels) -> frozenset:
+    """Parse ``issues.labels`` JSON (export schema) → frozenset of lowercase label names."""
+    decoded = _decode_issues_json_column(raw_labels)
+    if not decoded:
+        return frozenset()
+    names = []
+    for item in decoded:
+        if isinstance(item, dict):
+            n = item.get('name')
+            if n:
+                names.append(str(n).strip().lower())
+    return frozenset(names)
 
 
 def build_github_issue_mapping_info_snapshot(issue_row: dict) -> dict:

--- a/.github/scripts/github_issue_utils.py
+++ b/.github/scripts/github_issue_utils.py
@@ -6,6 +6,7 @@ Used by both the muted test analytics and issue management scripts.
 """
 
 import datetime as dt
+import json
 import re
 from collections import defaultdict
 from dataclasses import dataclass, field
@@ -239,11 +240,63 @@ def make_profile_id(branch: str, build_type: str) -> str:
     return f"{branch}:{build_type}"
 
 
+def _decode_issues_json_column(val):
+    """YDB ``Json`` / scan row value → Python object (dict/list) or None."""
+    if val is None:
+        return None
+    if isinstance(val, (dict, list)):
+        return val
+    if isinstance(val, str):
+        try:
+            return json.loads(val)
+        except json.JSONDecodeError:
+            return None
+    return None
+
+
+def build_github_issue_mapping_info_snapshot(issue_row: dict) -> dict:
+    """Single JSON payload for ``github_issue_mapping.info``: assignees, labels, exports meta.
+
+    ``issue_row`` is one row from the YDB ``issues`` table (same shape as ``export_issues_to_ydb``).
+    """
+    assignees = _decode_issues_json_column(issue_row.get('assignees')) or []
+    labels = _decode_issues_json_column(issue_row.get('labels')) or []
+    milestone = _decode_issues_json_column(issue_row.get('milestone'))
+    project_fields = _decode_issues_json_column(issue_row.get('project_fields'))
+    raw_info = issue_row.get('info')
+    if isinstance(raw_info, str):
+        try:
+            info_extra = json.loads(raw_info) if raw_info.strip() else {}
+        except json.JSONDecodeError:
+            info_extra = {}
+    elif isinstance(raw_info, dict):
+        info_extra = raw_info
+    else:
+        info_extra = {}
+
+    out = {
+        'assignees': assignees,
+        'labels': labels,
+        'issue_type': issue_row.get('issue_type'),
+        'author_login': issue_row.get('author_login'),
+        'repository_name': issue_row.get('repository_name'),
+        'project_status': issue_row.get('project_status'),
+        'project_owner': issue_row.get('project_owner'),
+        'project_priority': issue_row.get('project_priority'),
+        'info': info_extra,
+    }
+    if milestone is not None:
+        out['milestone'] = milestone
+    if project_fields is not None:
+        out['project_fields'] = project_fields
+    return out
+
+
 def create_test_issue_mapping(issues_data):
     """Create a mapping from test names to GitHub issue information
 
     Args:
-        issues_data (list): List of issue dictionaries with 'body', 'url', 'title', 'issue_number' fields
+        issues_data (list): Rows from YDB ``issues`` (body, url, labels, assignees, …).
 
     Returns:
         dict: Mapping from test name to list of issue information
@@ -259,6 +312,7 @@ def create_test_issue_mapping(issues_data):
 
         try:
             parsed = parse_body(body)
+            snapshot = build_github_issue_mapping_info_snapshot(issue)
 
             for test in parsed.tests:
                 if test not in test_to_issue:
@@ -268,9 +322,11 @@ def create_test_issue_mapping(issues_data):
                     'title': issue.get('title', ''),
                     'issue_number': issue.get('issue_number', 0),
                     'state': issue.get('state', ''),
+                    'state_reason': issue.get('state_reason'),
                     'created_at': issue.get('created_at', 0),
                     'branches': parsed.branches,
                     'build_type': parsed.build_type,
+                    'mapping_info': snapshot,
                 })
         except Exception as e:
             print(f"Warning: Could not parse issue body for issue {url}: {e}")

--- a/.github/scripts/tests/mute/update_mute_issues.py
+++ b/.github/scripts/tests/mute/update_mute_issues.py
@@ -273,6 +273,7 @@ def fetch_all_issues(org_name=ORG_NAME, project_id=PROJECT_ID):
                   title
                   url
                   state
+                  stateReason
                   body
                   createdAt
                   labels(first: 40) {
@@ -416,9 +417,14 @@ def generate_github_issue_title_and_body(test_data):
 def get_issues_and_tests_from_project(ORG_NAME, PROJECT_ID):
     """Project items → issue index.
 
-    Includes **open** issues and **closed** issues only when the GitHub label
-    ``manual-fast-unmute`` is present (fast-unmute without reopening the issue).
-    Other closed cards are skipped so downstream logic matches project 45 only.
+    Includes **open** issues.
+
+    Includes **closed** issues when either:
+    - GitHub label ``manual-fast-unmute`` is present (fast-unmute tracking without reopening), or
+    - ``stateReason`` is ``COMPLETED`` (manual close as done — still the canonical mute issue until
+      closed as not planned or reopened).
+
+    Other closed cards (e.g. ``NOT_PLANNED``) are skipped so mute tooling no longer matches them.
     """
     issues = fetch_all_issues(ORG_NAME, PROJECT_ID)
     all_issues_with_contet = {}
@@ -426,10 +432,16 @@ def get_issues_and_tests_from_project(ORG_NAME, PROJECT_ID):
         content = issue['content']
         if content:
             state = content.get('state')
+            state_reason = (content.get('stateReason') or '').strip().upper()
             label_nodes = (content.get('labels') or {}).get('nodes') or []
             label_names = [n['name'] for n in label_nodes if n and n.get('name')]
-            if state == 'CLOSED' and MANUAL_FAST_UNMUTE_GITHUB_LABEL not in label_names:
-                continue
+            if state == 'CLOSED':
+                if MANUAL_FAST_UNMUTE_GITHUB_LABEL in label_names:
+                    pass
+                elif state_reason == 'COMPLETED':
+                    pass
+                else:
+                    continue
 
             body = content['body']
             parsed = parse_body(body)
@@ -462,6 +474,7 @@ def get_issues_and_tests_from_project(ORG_NAME, PROJECT_ID):
             all_issues_with_contet[content['id']]['title'] = content['title']
             all_issues_with_contet[content['id']]['url'] = content['url']
             all_issues_with_contet[content['id']]['state'] = content['state']
+            all_issues_with_contet[content['id']]['state_reason'] = content.get('stateReason') or ''
             all_issues_with_contet[content['id']]['createdAt'] = content['createdAt']
             all_issues_with_contet[content['id']]['status_updated'] = status_updated
             all_issues_with_contet[content['id']]['status'] = status
@@ -505,24 +518,53 @@ def get_muted_tests_from_issues(issues_dict=None):
 
     # First, collect all issues for each (test, build_type) key
     for issue in issues_dict:
-        if issues_dict[issue]["state"] != 'CLOSED':
-            bt = issues_dict[issue].get('build_type') or DEFAULT_BUILD_TYPE
-            for test in issues_dict[issue]['tests']:
+        info = issues_dict[issue]
+        state = info['state']
+        state_reason = (info.get('state_reason') or '').strip().upper()
+        bt = info.get('build_type') or DEFAULT_BUILD_TYPE
+
+        # Open issues: reserve (test, build_type) for mute/issue automation.
+        # Closed as COMPLETED (with or without manual-fast-unmute label yet): same — do not open a duplicate.
+        if state == 'CLOSED':
+            if state_reason != 'COMPLETED':
+                continue
+            for test in info['tests']:
                 key = (test, bt)
                 if key not in muted_tests:
                     muted_tests[key] = []
                 muted_tests[key].append(
                     {
-                        'url': issues_dict[issue]['url'],
-                        'createdAt': issues_dict[issue]['createdAt'],
-                        'status_updated': issues_dict[issue]['status_updated'],
-                        'status': issues_dict[issue]['status'],
-                        'state': issues_dict[issue]['state'],
-                        'branches': issues_dict[issue]['branches'],
+                        'url': info['url'],
+                        'createdAt': info['createdAt'],
+                        'status_updated': info['status_updated'],
+                        'status': info['status'],
+                        'state': state,
+                        'branches': info['branches'],
                         'build_type': bt,
                         'id': issue,
                     }
                 )
+            continue
+
+        if state != 'OPEN':
+            continue
+
+        for test in info['tests']:
+            key = (test, bt)
+            if key not in muted_tests:
+                muted_tests[key] = []
+            muted_tests[key].append(
+                {
+                    'url': info['url'],
+                    'createdAt': info['createdAt'],
+                    'status_updated': info['status_updated'],
+                    'status': info['status'],
+                    'state': state,
+                    'branches': info['branches'],
+                    'build_type': bt,
+                    'id': issue,
+                }
+            )
     
     # Then, for each test, keep only the latest issue (by createdAt)
     for test in muted_tests:

--- a/.github/scripts/tests/mute/update_mute_issues.py
+++ b/.github/scripts/tests/mute/update_mute_issues.py
@@ -7,14 +7,17 @@ from urllib.parse import quote_plus
 _scripts_dir = os.path.normpath(os.path.join(os.path.dirname(os.path.abspath(__file__)), '..', '..'))
 if _scripts_dir not in sys.path:
     sys.path.insert(0, _scripts_dir)
-from github_issue_utils import parse_body, DEFAULT_BUILD_TYPE
+from github_issue_utils import (
+    DEFAULT_BUILD_TYPE,
+    MANUAL_FAST_UNMUTE_GITHUB_LABEL,
+    parse_body,
+)
 
 
 ORG_NAME = 'ydb-platform'
 REPO_NAME = 'ydb'
 PROJECT_ID = '45'
-# GitHub issue label set by ``mute/fast_unmute_github.py`` while fast-unmute rows exist.
-MANUAL_FAST_UNMUTE_GITHUB_LABEL = 'manual-fast-unmute'
+# Label constant: ``github_issue_utils.MANUAL_FAST_UNMUTE_GITHUB_LABEL`` (fast-unmute tracking).
 TEST_HISTORY_DASHBOARD = "https://datalens.yandex/4un3zdm0zcnyr"
 CURRENT_TEST_HISTORY_DASHBOARD = "https://datalens.yandex/34xnbsom67hcq?"
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Сценарии и поведение

### Mute workflow (GitHub Project 45, `update_mute_issues`, создание issue при mute)

| Сценарий | Было (проблема) | Стало |
|----------|-----------------|--------|
| Закрыли issue вручную как **Completed**, чтобы начать fast-track, но лейбла `manual-fast-unmute` ещё нет | Карточка **CLOSED** без лейбла **выкидывалась** из индекса проекта → связь mute ↔ issue терялась, мог завестись **дубликат** issue | В индекс входят **CLOSED + `stateReason` = COMPLETED** или при наличии лейбла `manual-fast-unmute`; NOT_PLANNED и др. причины без COMPLETED — по-прежнему не матчятся |
| Нужно не плодить issue, если уже есть актуальный (открыт или закрыт как completed для fast-track) | Закрытый Completed без лейбла не участвовал в `get_muted_tests_from_issues` | Учитываются **OPEN** и **CLOSED + COMPLETED** для резерва `(test, build_type)` |

### `github_issue_mapping` + `tests_monitor` / марты (последний issue по `created_at`)

| Сценарий | Было (проблема) | Стало |
|----------|-----------------|--------|
| Дубликат issue по ошибке **новее** по времени | «Последний созданный» мог быть ошибочный → не те ссылка / owner в мониторе | Закрытые **NOT_PLANNED** и **DUPLICATE** **исключаются** из выборки `issues` для маппинга |
| Дубли NOT_PLANNED / Duplicate в данных | Побеждал более новый даже после закрытия как не актуальный | Исключение на уровне запроса |

### Колонки маппинга и BI

| Сценарий | Решение |
|----------|---------|
| Нужны резолюция GitHub и снимок issue (assignees, labels, …) | Колонки **`github_issue_state_reason`**, **`info` (Json)**; заполнение из экспорта `issues` |

### `area_override` (effective owner в мониторе)

| Сценарий | Было / риск | Стало |
|----------|-------------|--------|
| Закрыли Completed для fast-track, лейбла ещё нет | Эвристика «закрыл бот» могла **преждевременно снять** override | Убрана; для **CLOSED + COMPLETED** без `manual-fast-unmute` override снимаем **только** при **`project_status` = Unmuted** |
| Ручной Completed и активный fast-track | Override должен сохраняться с лейблом | Пока есть **`manual-fast-unmute`**, override сохраняется |
| Fast-track успешно завершился | Лейбл снят, статус доски **Unmuted** | Без лейбла + **Unmuted** → override снимается |
| Обычное автозакрытие после размьюта ботом | Нужно вернуть TESTOWNERS | После **`project_status` = Unmuted** override снимается (не опираемся на `closed_by`) |
| NOT_PLANNED / DUPLICATE | — | Override не задаётся для таких закрытий в логике `resolve_area_override` |

---

## Ручная миграция YDB: добавление колонок в `github_issue_mapping`

Логический путь таблицы в конфиге: **`test_results/analytics/github_issue_mapping`** (полный путь в каталоге БД — как у вас заведено для analytics).

Выполнить вручную (подставьте полный путь к таблице в вашей БД, если отличается):

```sql
ALTER TABLE `test_results/analytics/github_issue_mapping`
  ADD COLUMN github_issue_state_reason Utf8;

ALTER TABLE `test_results/analytics/github_issue_mapping`
  ADD COLUMN info Json;
```

Поле **`area_override_since`** уже должно существовать со старых миграций; если таблица создавалась только начальным `CREATE` без этих колонок — проверьте наличие **`area_override_since`**; при отсутствии:

```sql
ALTER TABLE `test_results/analytics/github_issue_mapping`
  ADD COLUMN area_override_since Date;
```

Новые деплои могут опираться на обновлённый **`CREATE TABLE IF NOT EXISTS`** в `github_issue_mapping.py` (скрипт сам DDL для существующей таблицы не выполняет).

---

## Связанные файлы (кратко)

- `.github/scripts/tests/mute/update_mute_issues.py` — индекс проекта, `stateReason`, дубликаты mute issue.
- `.github/scripts/analytics/github_issue_mapping.py` — выборка `issues`, `resolve_area_override`, UPSERT маппинга.
- `.github/scripts/github_issue_utils.py` — `MANUAL_FAST_UNMUTE_GITHUB_LABEL`, снимок для `info`, `create_test_issue_mapping`.
- Марты: `test_muted_monitor_mart_with_issue.sql`, `muted_tests_with_issue_and_area.sql` — поля резолюции и `github_issue_info` при необходимости.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0c3ce88d-ed73-41ea-b5d0-a4d2b63c72ac"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0c3ce88d-ed73-41ea-b5d0-a4d2b63c72ac"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

