### PR TITLE
mute: post LLM-targeted debug-links comment and AI review label on new mute issues

### DIFF
--- a/.github/scripts/tests/mute/create_new_muted_ya.py
+++ b/.github/scripts/tests/mute/create_new_muted_ya.py
@@ -37,11 +37,7 @@ from mute.constants import (
 )
 from mute.naming import mute_file_line_to_tests_monitor_full_name
 from mute.mute_utils import dedicated_relative
-from mute.llm_debug_comment import (
-    DEFAULT_FAILURE_LOOKBACK_DAYS,
-    DEFAULT_LABEL as DEFAULT_AI_REVIEW_LABEL,
-    post_llm_debug_comment,
-)
+from mute.llm_debug_comment import post_llm_debug_comment
 from ydb_wrapper import YDBWrapper
 from github_issue_utils import DEFAULT_BUILD_TYPE, canonical_team_slug, make_profile_id
 
@@ -1049,9 +1045,6 @@ def create_mute_issues(
     branch='main',
     build_type=DEFAULT_BUILD_TYPE,
     ydb_wrapper=None,
-    add_debug_info=False,
-    ai_review_label=DEFAULT_AI_REVIEW_LABEL,
-    failures_window_days=DEFAULT_FAILURE_LOOKBACK_DAYS,
 ):
     tests_from_file = read_tests_from_file(file_path)
     issues_index = get_issues_and_tests_from_project(ORG_NAME, PROJECT_ID)
@@ -1208,17 +1201,14 @@ def create_mute_issues(
                 }
             )
 
-            if add_debug_info and issue_id:
-                test_full_names = [t['full_name'] for t in tests_in_issue if t.get('full_name')]
+            if issue_id:
                 post_llm_debug_comment(
                     ydb_wrapper,
                     issue_id=issue_id,
                     issue_url=issue_url,
-                    full_names=test_full_names,
+                    full_names=[t['full_name'] for t in tests_in_issue if t.get('full_name')],
                     branch=first_test.get('branch', branch),
                     build_type=first_test.get('build_type', build_type),
-                    label=ai_review_label,
-                    window_days=failures_window_days,
                 )
 
             try:
@@ -1581,9 +1571,6 @@ def mute_worker(args):
                 branch=args.branch,
                 build_type=build_type,
                 ydb_wrapper=ydb_wrapper,
-                add_debug_info=args.add_debug_info,
-                ai_review_label=args.ai_review_label,
-                failures_window_days=mute_window_days,
             )
 
             try:
@@ -1643,24 +1630,6 @@ if __name__ == "__main__":
         default=DEFAULT_BUILD_TYPE,
         dest='build_type',
         help='tests_monitor build_type when loading monitor rows (default: relwithdebinfo)',
-    )
-    create_issues_parser.add_argument(
-        '--add_debug_info',
-        action=argparse.BooleanOptionalAction,
-        default=False,
-        help=(
-            'For each newly created mute issue post a debug-links comment '
-            'targeted at an LLM reviewer and attach an AI review label '
-            '(default: False).'
-        ),
-    )
-    create_issues_parser.add_argument(
-        '--ai_review_label',
-        default=DEFAULT_AI_REVIEW_LABEL,
-        help=(
-            'GitHub label to attach to mute issues that received the '
-            f'debug-links comment (default: {DEFAULT_AI_REVIEW_LABEL!r}).'
-        ),
     )
 
     args = parser.parse_args()

--- a/.github/scripts/tests/mute/create_new_muted_ya.py
+++ b/.github/scripts/tests/mute/create_new_muted_ya.py
@@ -37,6 +37,11 @@ from mute.constants import (
 )
 from mute.naming import mute_file_line_to_tests_monitor_full_name
 from mute.mute_utils import dedicated_relative
+from mute.llm_debug_comment import (
+    DEFAULT_FAILURE_LOOKBACK_DAYS,
+    DEFAULT_LABEL as DEFAULT_AI_REVIEW_LABEL,
+    post_llm_debug_comment,
+)
 from ydb_wrapper import YDBWrapper
 from github_issue_utils import DEFAULT_BUILD_TYPE, canonical_team_slug, make_profile_id
 
@@ -1043,6 +1048,10 @@ def create_mute_issues(
     close_issues=True,
     branch='main',
     build_type=DEFAULT_BUILD_TYPE,
+    ydb_wrapper=None,
+    add_debug_info=False,
+    ai_review_label=DEFAULT_AI_REVIEW_LABEL,
+    failures_window_days=DEFAULT_FAILURE_LOOKBACK_DAYS,
 ):
     tests_from_file = read_tests_from_file(file_path)
     issues_index = get_issues_and_tests_from_project(ORG_NAME, PROJECT_ID)
@@ -1181,26 +1190,42 @@ def create_mute_issues(
     results = []
     queue_items = []
     for item in prepared_tests_by_suite:
-        title, body = generate_github_issue_title_and_body(prepared_tests_by_suite[item])
-        raw_owner = prepared_tests_by_suite[item][0]['owner']
+        tests_in_issue = prepared_tests_by_suite[item]
+        first_test = tests_in_issue[0]
+        title, body = generate_github_issue_title_and_body(tests_in_issue)
+        raw_owner = first_test['owner']
         owner_value = canonical_team_slug(raw_owner)
         result = create_and_add_issue_to_project(title, body, state='Muted', owner=owner_value)
         if not result:
             break
         else:
             issue_url = result['issue_url']
+            issue_id = result.get('issue_id')
             results.append(
                 {
                     'message': f"Created issue '{title}' for TEAM:@ydb-platform/{owner_value}, url {issue_url}",
                     'owner': owner_value
                 }
             )
+
+            if add_debug_info and issue_id:
+                test_full_names = [t['full_name'] for t in tests_in_issue if t.get('full_name')]
+                post_llm_debug_comment(
+                    ydb_wrapper,
+                    issue_id=issue_id,
+                    issue_url=issue_url,
+                    full_names=test_full_names,
+                    branch=first_test.get('branch', branch),
+                    build_type=first_test.get('build_type', build_type),
+                    label=ai_review_label,
+                    window_days=failures_window_days,
+                )
+
             try:
                 issue_number = int(issue_url.rstrip('/').split('/')[-1])
             except (ValueError, IndexError):
                 issue_number = None
             if issue_number:
-                first_test = prepared_tests_by_suite[item][0]
                 queue_items.append({
                     'github_issue_number': issue_number,
                     'github_issue_url': issue_url,
@@ -1555,6 +1580,10 @@ def mute_worker(args):
                 close_issues=args.close_issues,
                 branch=args.branch,
                 build_type=build_type,
+                ydb_wrapper=ydb_wrapper,
+                add_debug_info=args.add_debug_info,
+                ai_review_label=args.ai_review_label,
+                failures_window_days=mute_window_days,
             )
 
             try:
@@ -1614,6 +1643,24 @@ if __name__ == "__main__":
         default=DEFAULT_BUILD_TYPE,
         dest='build_type',
         help='tests_monitor build_type when loading monitor rows (default: relwithdebinfo)',
+    )
+    create_issues_parser.add_argument(
+        '--add_debug_info',
+        action=argparse.BooleanOptionalAction,
+        default=False,
+        help=(
+            'For each newly created mute issue post a debug-links comment '
+            'targeted at an LLM reviewer and attach an AI review label '
+            '(default: False).'
+        ),
+    )
+    create_issues_parser.add_argument(
+        '--ai_review_label',
+        default=DEFAULT_AI_REVIEW_LABEL,
+        help=(
+            'GitHub label to attach to mute issues that received the '
+            f'debug-links comment (default: {DEFAULT_AI_REVIEW_LABEL!r}).'
+        ),
     )
 
     args = parser.parse_args()

--- a/.github/scripts/tests/mute/llm_debug_comment.py
+++ b/.github/scripts/tests/mute/llm_debug_comment.py
@@ -1,0 +1,392 @@
+"""LLM-targeted debug-links comment for newly created mute issues.
+
+Posts one (or several, if it doesn't fit GitHub's comment size limit) markdown
+comments to a freshly-created mute issue, listing for each test the most recent
+failing/muted CI run and the artifact links available in ``test_results``
+(stderr / stdout / log / logsdir / job run URL / history dashboard).
+
+The comment is wrapped in a hidden HTML hint that asks any LLM reviewing the
+issue to classify the failure (TEST_ISSUE / YDB_ISSUE / TEST_INFRA_ISSUE),
+locate the most likely root cause and offending commit, and propose a fix.
+
+After the comment is posted the configured GitHub label is attached so an AI
+review workflow can pick the issue up.
+
+This module is **best-effort**: any failure (missing table, invalid token,
+network issue, etc.) is logged as a warning but never raises — issue creation
+is the primary action and must not regress because the LLM annotation failed.
+"""
+
+from __future__ import annotations
+
+import datetime
+import logging
+import re
+from typing import Dict, Iterable, List, Optional, Sequence
+from urllib.parse import quote_plus
+
+from mute.update_mute_issues import (
+    CURRENT_TEST_HISTORY_DASHBOARD,
+    add_issue_comment,
+    add_issue_label,
+)
+
+
+DEFAULT_LABEL = 'needs-ai-review'
+DEFAULT_FAILURE_LOOKBACK_DAYS = 7
+DEFAULT_MAX_COMMENT_LENGTH = 60000
+
+# CI jobs that publish results to ``test_results`` and whose artifacts are
+# meaningful for debugging mutes. We deliberately keep this list small and
+# explicit instead of accepting any job_name — random PR jobs would pollute
+# the "latest failing run" picked for a mute.
+DEFAULT_JOB_NAMES: Sequence[str] = (
+    'Nightly-run',
+    'Regression-run',
+    'Regression-run_Large',
+    'Regression-run_Small_and_Medium',
+    'Regression-run_compatibility',
+    'Regression-whitelist-run',
+    'Postcommit_relwithdebinfo',
+    'Postcommit_asan',
+)
+
+_GITHUB_RUN_URL_TEMPLATE = "https://github.com/ydb-platform/ydb/actions/runs/{job_id}"
+
+_SANITIZER_PATTERNS = (
+    r'(ERROR|WARNING|SUMMARY): '
+    r'(AddressSanitizer|MemorySanitizer|ThreadSanitizer|LeakSanitizer|UndefinedBehaviorSanitizer)',
+    r'==\d+==\s*(ERROR|WARNING|SUMMARY): '
+    r'(AddressSanitizer|MemorySanitizer|ThreadSanitizer|LeakSanitizer|UndefinedBehaviorSanitizer)',
+    r'runtime error:',
+    r'detected memory leaks',
+)
+_SANITIZER_RE = re.compile('|'.join(_SANITIZER_PATTERNS), re.IGNORECASE | re.MULTILINE)
+
+_HEADER = '### Debug links (latest failed run)'
+
+# Hidden hint for the LLM; not rendered in GitHub UI but available in the raw
+# comment body that an AI agent fetches via the API.
+_LLM_HINT = (
+    "<!-- LLM: please classify the failure as one of "
+    "TEST_ISSUE / YDB_ISSUE / TEST_INFRA_ISSUE; try to find the root cause "
+    "and the commit that most likely introduced it; estimate severity "
+    "(HIGH / MEDIUM / LOW); when possible, propose a fix. -->"
+)
+
+
+def _sql_str_in(values: Iterable[str]) -> str:
+    """Render a sequence of strings as a comma-separated SQL ``IN`` clause body."""
+    escaped = [str(v).replace("'", "''") for v in values if v is not None]
+    return ', '.join(f"'{v}'" for v in escaped)
+
+
+def _format_run_timestamp(value) -> str:
+    if value is None:
+        return 'unknown'
+    if isinstance(value, datetime.datetime):
+        return value.astimezone(datetime.timezone.utc).strftime('%Y-%m-%d %H:%M:%S UTC')
+    if isinstance(value, datetime.date):
+        return value.strftime('%Y-%m-%d')
+    if isinstance(value, int):
+        return datetime.datetime.fromtimestamp(
+            value / 1_000_000, tz=datetime.timezone.utc
+        ).strftime('%Y-%m-%d %H:%M:%S UTC')
+    return str(value)
+
+
+def _is_sanitizer_issue(error_text: object) -> bool:
+    return bool(error_text) and bool(_SANITIZER_RE.search(str(error_text)))
+
+
+def _normalize_error_type(error_type, status_description) -> str:
+    if _is_sanitizer_issue(status_description):
+        return 'SANITIZER'
+    return str(error_type or '').upper() or 'n/a'
+
+
+def _split_full_name(full_name: str) -> Optional[tuple]:
+    if not full_name or '/' not in full_name:
+        return None
+    suite_folder, test_name = full_name.rsplit('/', 1)
+    return suite_folder, test_name
+
+
+def _compose_full_name_from_row(row: Dict) -> str:
+    full_name = row.get('full_name')
+    if full_name:
+        return str(full_name)
+    suite_folder = row.get('suite_folder')
+    test_name = row.get('test_name')
+    if suite_folder and test_name:
+        return f"{suite_folder}/{test_name}"
+    return ''
+
+
+def _history_link(full_name: str, branch: str, build_type: str) -> str:
+    return (
+        f"{CURRENT_TEST_HISTORY_DASHBOARD}"
+        f"full_name={quote_plus(f'__in_{full_name}')}"
+        f"&branch={quote_plus(str(branch or 'main'))}"
+        f"&build_type={quote_plus(str(build_type or ''))}"
+    )
+
+
+def _md_escape_cell(value: object) -> str:
+    return str(value).replace('|', '\\|')
+
+
+def load_latest_failure_links(
+    ydb_wrapper,
+    branch: str,
+    build_type: str,
+    full_names: Sequence[str],
+    *,
+    window_days: int = DEFAULT_FAILURE_LOOKBACK_DAYS,
+    job_names: Sequence[str] = DEFAULT_JOB_NAMES,
+) -> Dict[str, Dict]:
+    """Fetch the most recent failing/muted run for each ``full_name``.
+
+    Returns a mapping ``full_name -> {job_id, run_url, status, error_type,
+    status_description, run_timestamp, duration, stderr, stdout, log, logsdir}``.
+
+    Only failures with explicit job names from ``job_names`` are considered, and
+    PR-manual reruns (``pull`` LIKE ``%manual%``) are filtered out.
+    """
+    full_names = [str(n) for n in full_names if n]
+    if not full_names:
+        return {}
+
+    try:
+        table_path = ydb_wrapper.get_table_path('test_results')
+    except KeyError:
+        logging.warning('test_results table is not registered in ydb_qa_config — debug links disabled')
+        return {}
+
+    pairs = []
+    target_names = set(full_names)
+    for name in target_names:
+        parts = _split_full_name(name)
+        if parts is None:
+            continue
+        suite, test = parts
+        pairs.append((suite.replace("'", "''"), test.replace("'", "''")))
+    if not pairs:
+        return {}
+
+    branch_esc = str(branch).replace("'", "''")
+    bt_esc = str(build_type).replace("'", "''")
+    jobs_in_sql = _sql_str_in(job_names)
+    pair_predicate = ' OR '.join(
+        f"(suite_folder = '{suite}' AND test_name = '{test}')" for suite, test in pairs
+    )
+    query = f"""
+    SELECT
+        suite_folder, test_name, job_id, status, error_type, status_description,
+        duration, run_timestamp, stderr, stdout, log, logsdir
+    FROM `{table_path}`
+    WHERE branch = '{branch_esc}'
+        AND build_type = '{bt_esc}'
+        AND job_name IN ({jobs_in_sql})
+        AND (pull IS NULL OR NOT String::Contains(pull, 'manual'))
+        AND ({pair_predicate})
+        AND status IN ('failure', 'error', 'mute')
+        AND run_timestamp >= CurrentUtcTimestamp() - {int(window_days)} * Interval("P1D")
+    ORDER BY run_timestamp DESC
+    """
+    try:
+        rows = ydb_wrapper.execute_scan_query(query, query_name='mute_issue_llm_debug_links')
+    except Exception as exc:
+        logging.warning('Failed to load debug links from test_results: %s', exc)
+        return {}
+
+    latest: Dict[str, Dict] = {}
+    for row in rows:
+        full_name = _compose_full_name_from_row(row)
+        if full_name not in target_names or full_name in latest:
+            continue
+        job_id = row.get('job_id')
+        latest[full_name] = {
+            'job_id': job_id,
+            'run_url': _GITHUB_RUN_URL_TEMPLATE.format(job_id=job_id) if job_id else '',
+            'test_name': row.get('test_name'),
+            'status': row.get('status') or 'unknown',
+            'error_type': row.get('error_type') or '',
+            'status_description': row.get('status_description') or '',
+            'duration': row.get('duration'),
+            'run_timestamp': _format_run_timestamp(row.get('run_timestamp')),
+            'stderr': row.get('stderr'),
+            'stdout': row.get('stdout'),
+            'log': row.get('log'),
+            'logsdir': row.get('logsdir'),
+        }
+    return latest
+
+
+def _format_duration(value) -> str:
+    if value is None:
+        return 'n/a'
+    try:
+        return f"`{float(value):.2f}s`"
+    except (TypeError, ValueError):
+        return f"`{_md_escape_cell(value)}`"
+
+
+def _link_cell(url) -> str:
+    return f"[link]({url})" if url else 'n/a'
+
+
+def build_debug_links_table(
+    full_names: Sequence[str],
+    debug_links: Dict[str, Dict],
+    branch: str,
+    build_type: str,
+) -> str:
+    """Build the markdown table body (without the header / hint)."""
+    lines = [
+        "| test_name | status | type | duration | last_run | history | run | stderr | stdout | log | logsdir |",
+        "|---|---|---|---|---|---|---|---|---|---|---|",
+    ]
+    for full_name in sorted({str(n) for n in full_names if n}):
+        data = debug_links.get(full_name)
+        short_name = full_name.rsplit('/', 1)[-1] if '/' in full_name else full_name
+        if data and data.get('test_name'):
+            short_name = str(data['test_name'])
+        name_cell = f"`{_md_escape_cell(short_name)}`"
+        history = _history_link(full_name, branch, build_type)
+
+        if not data:
+            lines.append(
+                f"| {name_cell} | n/a | n/a | n/a | n/a | "
+                f"{_link_cell(history)} | n/a | n/a | n/a | n/a | n/a |"
+            )
+            continue
+
+        lines.append(
+            "| {name} | `{status}` | `{etype}` | {duration} | `{ts}` | "
+            "{history} | {run} | {stderr} | {stdout} | {log} | {logsdir} |".format(
+                name=name_cell,
+                status=_md_escape_cell(data.get('status') or 'unknown'),
+                etype=_md_escape_cell(_normalize_error_type(
+                    data.get('error_type'), data.get('status_description'),
+                )),
+                duration=_format_duration(data.get('duration')),
+                ts=_md_escape_cell(data.get('run_timestamp') or 'unknown'),
+                history=_link_cell(history),
+                run=_link_cell(data.get('run_url')),
+                stderr=_link_cell(data.get('stderr')),
+                stdout=_link_cell(data.get('stdout')),
+                log=_link_cell(data.get('log')),
+                logsdir=_link_cell(data.get('logsdir')),
+            )
+        )
+
+    if not any(debug_links.values()):
+        lines.append("")
+        lines.append("_No stderr/stdout/log/logsdir links found in recent failed runs._")
+    return "\n".join(lines)
+
+
+def split_into_comments(table_body: str, max_length: int = DEFAULT_MAX_COMMENT_LENGTH) -> List[str]:
+    """Wrap ``table_body`` with header + LLM hint, splitting into multiple comments if needed.
+
+    Splits on table rows so each chunk stays valid markdown.
+    """
+    body = (table_body or '').strip()
+    prefix_overhead = len(_HEADER) + 1 + len(_LLM_HINT) + 1
+    if not body:
+        return [f"{_HEADER}\n{_LLM_HINT}"]
+
+    rows = body.split('\n')
+    # Header rows of the markdown table: title row + separator row.
+    if len(rows) >= 2 and rows[0].startswith('|') and set(rows[1].replace('|', '').strip()) <= {'-', ':', ' '}:
+        table_header = '\n'.join(rows[:2])
+        data_rows = rows[2:]
+    else:
+        table_header = ''
+        data_rows = rows
+
+    chunks: List[str] = []
+    current_rows: List[str] = []
+    current_len = 0
+    base_chunk_len = (len(table_header) + 1) if table_header else 0
+
+    def _flush() -> None:
+        nonlocal current_rows, current_len
+        if not current_rows:
+            return
+        block = '\n'.join(([table_header] if table_header else []) + current_rows)
+        chunks.append(block)
+        current_rows = []
+        current_len = 0
+
+    for row in data_rows:
+        row_len = len(row) + 1
+        if current_rows and (
+            prefix_overhead + base_chunk_len + current_len + row_len > max_length
+        ):
+            _flush()
+        current_rows.append(row)
+        current_len += row_len
+    _flush()
+
+    if not chunks:
+        chunks = [body]
+
+    if len(chunks) == 1:
+        return [f"{_HEADER}\n{_LLM_HINT}\n{chunks[0]}"]
+
+    total = len(chunks)
+    return [
+        f"{_HEADER} (part {idx}/{total})\n{_LLM_HINT}\n{chunk}"
+        for idx, chunk in enumerate(chunks, start=1)
+    ]
+
+
+def post_llm_debug_comment(
+    ydb_wrapper,
+    issue_id: str,
+    issue_url: str,
+    full_names: Sequence[str],
+    branch: str,
+    build_type: str,
+    *,
+    label: str = DEFAULT_LABEL,
+    window_days: int = DEFAULT_FAILURE_LOOKBACK_DAYS,
+    max_comment_length: int = DEFAULT_MAX_COMMENT_LENGTH,
+    job_names: Sequence[str] = DEFAULT_JOB_NAMES,
+) -> bool:
+    """Post the LLM-targeted debug-links comment(s) and attach the AI review label.
+
+    Best-effort: returns ``True`` when at least the comment was posted; logs and
+    returns ``False`` on any failure without raising.
+    """
+    if not issue_id:
+        logging.warning('post_llm_debug_comment: empty issue_id, skipping')
+        return False
+    full_names = [str(n) for n in full_names if n]
+    if not full_names:
+        return False
+
+    try:
+        debug_links = load_latest_failure_links(
+            ydb_wrapper,
+            branch=branch,
+            build_type=build_type,
+            full_names=full_names,
+            window_days=window_days,
+            job_names=job_names,
+        )
+        table_body = build_debug_links_table(full_names, debug_links, branch, build_type)
+        chunks = split_into_comments(table_body, max_length=max_comment_length)
+        for chunk in chunks:
+            add_issue_comment(issue_id, chunk)
+    except Exception as exc:
+        logging.warning('Failed to post LLM debug comment to %s: %s', issue_url, exc)
+        return False
+
+    try:
+        add_issue_label(issue_id, label)
+    except Exception as exc:
+        logging.warning('Failed to add label %r to %s: %s', label, issue_url, exc)
+    return True

--- a/.github/scripts/tests/mute/llm_debug_comment.py
+++ b/.github/scripts/tests/mute/llm_debug_comment.py
@@ -1,28 +1,21 @@
 """LLM-targeted debug-links comment for newly created mute issues.
 
-Posts one (or several, if it doesn't fit GitHub's comment size limit) markdown
-comments to a freshly-created mute issue, listing for each test the most recent
-failing/muted CI run and the artifact links available in ``test_results``
-(stderr / stdout / log / logsdir / job run URL / history dashboard).
+After a mute issue is created we post one markdown comment listing the latest
+failing/muted CI run for every test in the issue (job run URL, history
+dashboard, stderr / stdout / log / logsdir) and attach an AI review label so
+a downstream LLM workflow can pick the issue up. The comment carries a hidden
+hint asking the LLM to classify the failure, find a likely root cause and
+propose a fix.
 
-The comment is wrapped in a hidden HTML hint that asks any LLM reviewing the
-issue to classify the failure (TEST_ISSUE / YDB_ISSUE / TEST_INFRA_ISSUE),
-locate the most likely root cause and offending commit, and propose a fix.
-
-After the comment is posted the configured GitHub label is attached so an AI
-review workflow can pick the issue up.
-
-This module is **best-effort**: any failure (missing table, invalid token,
-network issue, etc.) is logged as a warning but never raises — issue creation
-is the primary action and must not regress because the LLM annotation failed.
+Best-effort: any YDB / GitHub failure is logged but never raised — issue
+creation is the primary action and must not regress because of this module.
 """
 
 from __future__ import annotations
 
 import datetime
 import logging
-import re
-from typing import Dict, Iterable, List, Optional, Sequence
+from typing import Dict, Sequence
 from urllib.parse import quote_plus
 
 from mute.update_mute_issues import (
@@ -32,15 +25,13 @@ from mute.update_mute_issues import (
 )
 
 
-DEFAULT_LABEL = 'needs-ai-review'
-DEFAULT_FAILURE_LOOKBACK_DAYS = 7
-DEFAULT_MAX_COMMENT_LENGTH = 60000
+AI_REVIEW_LABEL = 'needs-ai-review'
+FAILURE_LOOKBACK_DAYS = 7
+MAX_COMMENT_LENGTH = 60000
 
-# CI jobs that publish results to ``test_results`` and whose artifacts are
-# meaningful for debugging mutes. We deliberately keep this list small and
-# explicit instead of accepting any job_name — random PR jobs would pollute
-# the "latest failing run" picked for a mute.
-DEFAULT_JOB_NAMES: Sequence[str] = (
+# CI jobs whose artifacts are meaningful for debugging mutes. Restricting to
+# this allowlist keeps PR / manual reruns out of the "latest failing run".
+_JOB_NAMES = (
     'Nightly-run',
     'Regression-run',
     'Regression-run_Large',
@@ -51,22 +42,6 @@ DEFAULT_JOB_NAMES: Sequence[str] = (
     'Postcommit_asan',
 )
 
-_GITHUB_RUN_URL_TEMPLATE = "https://github.com/ydb-platform/ydb/actions/runs/{job_id}"
-
-_SANITIZER_PATTERNS = (
-    r'(ERROR|WARNING|SUMMARY): '
-    r'(AddressSanitizer|MemorySanitizer|ThreadSanitizer|LeakSanitizer|UndefinedBehaviorSanitizer)',
-    r'==\d+==\s*(ERROR|WARNING|SUMMARY): '
-    r'(AddressSanitizer|MemorySanitizer|ThreadSanitizer|LeakSanitizer|UndefinedBehaviorSanitizer)',
-    r'runtime error:',
-    r'detected memory leaks',
-)
-_SANITIZER_RE = re.compile('|'.join(_SANITIZER_PATTERNS), re.IGNORECASE | re.MULTILINE)
-
-_HEADER = '### Debug links (latest failed run)'
-
-# Hidden hint for the LLM; not rendered in GitHub UI but available in the raw
-# comment body that an AI agent fetches via the API.
 _LLM_HINT = (
     "<!-- LLM: please classify the failure as one of "
     "TEST_ISSUE / YDB_ISSUE / TEST_INFRA_ISSUE; try to find the root cause "
@@ -75,52 +50,14 @@ _LLM_HINT = (
 )
 
 
-def _sql_str_in(values: Iterable[str]) -> str:
-    """Render a sequence of strings as a comma-separated SQL ``IN`` clause body."""
-    escaped = [str(v).replace("'", "''") for v in values if v is not None]
-    return ', '.join(f"'{v}'" for v in escaped)
-
-
-def _format_run_timestamp(value) -> str:
-    if value is None:
-        return 'unknown'
+def _format_ts(value) -> str:
     if isinstance(value, datetime.datetime):
         return value.astimezone(datetime.timezone.utc).strftime('%Y-%m-%d %H:%M:%S UTC')
-    if isinstance(value, datetime.date):
-        return value.strftime('%Y-%m-%d')
     if isinstance(value, int):
         return datetime.datetime.fromtimestamp(
-            value / 1_000_000, tz=datetime.timezone.utc
+            value / 1_000_000, tz=datetime.timezone.utc,
         ).strftime('%Y-%m-%d %H:%M:%S UTC')
-    return str(value)
-
-
-def _is_sanitizer_issue(error_text: object) -> bool:
-    return bool(error_text) and bool(_SANITIZER_RE.search(str(error_text)))
-
-
-def _normalize_error_type(error_type, status_description) -> str:
-    if _is_sanitizer_issue(status_description):
-        return 'SANITIZER'
-    return str(error_type or '').upper() or 'n/a'
-
-
-def _split_full_name(full_name: str) -> Optional[tuple]:
-    if not full_name or '/' not in full_name:
-        return None
-    suite_folder, test_name = full_name.rsplit('/', 1)
-    return suite_folder, test_name
-
-
-def _compose_full_name_from_row(row: Dict) -> str:
-    full_name = row.get('full_name')
-    if full_name:
-        return str(full_name)
-    suite_folder = row.get('suite_folder')
-    test_name = row.get('test_name')
-    if suite_folder and test_name:
-        return f"{suite_folder}/{test_name}"
-    return ''
+    return str(value or 'unknown')
 
 
 def _history_link(full_name: str, branch: str, build_type: str) -> str:
@@ -132,66 +69,45 @@ def _history_link(full_name: str, branch: str, build_type: str) -> str:
     )
 
 
-def _md_escape_cell(value: object) -> str:
-    return str(value).replace('|', '\\|')
+def _link(url) -> str:
+    return f"[link]({url})" if url else 'n/a'
 
 
-def load_latest_failure_links(
-    ydb_wrapper,
-    branch: str,
-    build_type: str,
-    full_names: Sequence[str],
-    *,
-    window_days: int = DEFAULT_FAILURE_LOOKBACK_DAYS,
-    job_names: Sequence[str] = DEFAULT_JOB_NAMES,
-) -> Dict[str, Dict]:
-    """Fetch the most recent failing/muted run for each ``full_name``.
-
-    Returns a mapping ``full_name -> {job_id, run_url, status, error_type,
-    status_description, run_timestamp, duration, stderr, stdout, log, logsdir}``.
-
-    Only failures with explicit job names from ``job_names`` are considered, and
-    PR-manual reruns (``pull`` LIKE ``%manual%``) are filtered out.
-    """
-    full_names = [str(n) for n in full_names if n]
-    if not full_names:
+def _load_latest_failures(ydb_wrapper, branch, build_type, full_names) -> Dict[str, Dict]:
+    """Return ``full_name -> latest failing/muted CI run row`` from ``test_results``."""
+    pairs = []
+    target = set(full_names)
+    for name in target:
+        if '/' not in name:
+            continue
+        suite, test = name.rsplit('/', 1)
+        pairs.append((suite.replace("'", "''"), test.replace("'", "''")))
+    if not pairs:
         return {}
 
     try:
         table_path = ydb_wrapper.get_table_path('test_results')
     except KeyError:
-        logging.warning('test_results table is not registered in ydb_qa_config — debug links disabled')
-        return {}
-
-    pairs = []
-    target_names = set(full_names)
-    for name in target_names:
-        parts = _split_full_name(name)
-        if parts is None:
-            continue
-        suite, test = parts
-        pairs.append((suite.replace("'", "''"), test.replace("'", "''")))
-    if not pairs:
+        logging.warning('test_results not registered in ydb_qa_config — debug links disabled')
         return {}
 
     branch_esc = str(branch).replace("'", "''")
     bt_esc = str(build_type).replace("'", "''")
-    jobs_in_sql = _sql_str_in(job_names)
-    pair_predicate = ' OR '.join(
-        f"(suite_folder = '{suite}' AND test_name = '{test}')" for suite, test in pairs
+    jobs_in = ', '.join(f"'{j}'" for j in _JOB_NAMES)
+    pair_pred = ' OR '.join(
+        f"(suite_folder = '{s}' AND test_name = '{t}')" for s, t in pairs
     )
     query = f"""
-    SELECT
-        suite_folder, test_name, job_id, status, error_type, status_description,
-        duration, run_timestamp, stderr, stdout, log, logsdir
+    SELECT suite_folder, test_name, job_id, status, error_type, run_timestamp,
+           stderr, stdout, log, logsdir
     FROM `{table_path}`
     WHERE branch = '{branch_esc}'
         AND build_type = '{bt_esc}'
-        AND job_name IN ({jobs_in_sql})
+        AND job_name IN ({jobs_in})
         AND (pull IS NULL OR NOT String::Contains(pull, 'manual'))
-        AND ({pair_predicate})
+        AND ({pair_pred})
         AND status IN ('failure', 'error', 'mute')
-        AND run_timestamp >= CurrentUtcTimestamp() - {int(window_days)} * Interval("P1D")
+        AND run_timestamp >= CurrentUtcTimestamp() - {FAILURE_LOOKBACK_DAYS} * Interval("P1D")
     ORDER BY run_timestamp DESC
     """
     try:
@@ -202,191 +118,70 @@ def load_latest_failure_links(
 
     latest: Dict[str, Dict] = {}
     for row in rows:
-        full_name = _compose_full_name_from_row(row)
-        if full_name not in target_names or full_name in latest:
+        suite = row.get('suite_folder')
+        test = row.get('test_name')
+        if not suite or not test:
             continue
-        job_id = row.get('job_id')
-        latest[full_name] = {
-            'job_id': job_id,
-            'run_url': _GITHUB_RUN_URL_TEMPLATE.format(job_id=job_id) if job_id else '',
-            'test_name': row.get('test_name'),
-            'status': row.get('status') or 'unknown',
-            'error_type': row.get('error_type') or '',
-            'status_description': row.get('status_description') or '',
-            'duration': row.get('duration'),
-            'run_timestamp': _format_run_timestamp(row.get('run_timestamp')),
-            'stderr': row.get('stderr'),
-            'stdout': row.get('stdout'),
-            'log': row.get('log'),
-            'logsdir': row.get('logsdir'),
-        }
+        full_name = f"{suite}/{test}"
+        if full_name not in target or full_name in latest:
+            continue
+        latest[full_name] = row
     return latest
 
 
-def _format_duration(value) -> str:
-    if value is None:
-        return 'n/a'
-    try:
-        return f"`{float(value):.2f}s`"
-    except (TypeError, ValueError):
-        return f"`{_md_escape_cell(value)}`"
-
-
-def _link_cell(url) -> str:
-    return f"[link]({url})" if url else 'n/a'
-
-
-def build_debug_links_table(
-    full_names: Sequence[str],
-    debug_links: Dict[str, Dict],
-    branch: str,
-    build_type: str,
-) -> str:
-    """Build the markdown table body (without the header / hint)."""
+def _build_comment(full_names: Sequence[str], rows: Dict[str, Dict],
+                   branch: str, build_type: str) -> str:
     lines = [
-        "| test_name | status | type | duration | last_run | history | run | stderr | stdout | log | logsdir |",
-        "|---|---|---|---|---|---|---|---|---|---|---|",
+        '### Debug links (latest failed run)',
+        _LLM_HINT,
+        '',
+        '| test | status | type | last_run | history | run | stderr | stdout | log | logsdir |',
+        '|---|---|---|---|---|---|---|---|---|---|',
     ]
-    for full_name in sorted({str(n) for n in full_names if n}):
-        data = debug_links.get(full_name)
-        short_name = full_name.rsplit('/', 1)[-1] if '/' in full_name else full_name
-        if data and data.get('test_name'):
-            short_name = str(data['test_name'])
-        name_cell = f"`{_md_escape_cell(short_name)}`"
+    for full_name in sorted(set(full_names)):
+        row = rows.get(full_name)
         history = _history_link(full_name, branch, build_type)
-
-        if not data:
+        short = full_name.rsplit('/', 1)[-1]
+        if not row:
             lines.append(
-                f"| {name_cell} | n/a | n/a | n/a | n/a | "
-                f"{_link_cell(history)} | n/a | n/a | n/a | n/a | n/a |"
+                f"| `{short}` | n/a | n/a | n/a | {_link(history)} | n/a | n/a | n/a | n/a | n/a |"
             )
             continue
-
+        job_id = row.get('job_id')
+        run_url = f"https://github.com/ydb-platform/ydb/actions/runs/{job_id}" if job_id else ''
         lines.append(
-            "| {name} | `{status}` | `{etype}` | {duration} | `{ts}` | "
-            "{history} | {run} | {stderr} | {stdout} | {log} | {logsdir} |".format(
-                name=name_cell,
-                status=_md_escape_cell(data.get('status') or 'unknown'),
-                etype=_md_escape_cell(_normalize_error_type(
-                    data.get('error_type'), data.get('status_description'),
-                )),
-                duration=_format_duration(data.get('duration')),
-                ts=_md_escape_cell(data.get('run_timestamp') or 'unknown'),
-                history=_link_cell(history),
-                run=_link_cell(data.get('run_url')),
-                stderr=_link_cell(data.get('stderr')),
-                stdout=_link_cell(data.get('stdout')),
-                log=_link_cell(data.get('log')),
-                logsdir=_link_cell(data.get('logsdir')),
-            )
+            f"| `{short}` "
+            f"| `{row.get('status') or 'unknown'}` "
+            f"| `{(row.get('error_type') or 'n/a').upper()}` "
+            f"| `{_format_ts(row.get('run_timestamp'))}` "
+            f"| {_link(history)} "
+            f"| {_link(run_url)} "
+            f"| {_link(row.get('stderr'))} "
+            f"| {_link(row.get('stdout'))} "
+            f"| {_link(row.get('log'))} "
+            f"| {_link(row.get('logsdir'))} |"
         )
 
-    if not any(debug_links.values()):
-        lines.append("")
-        lines.append("_No stderr/stdout/log/logsdir links found in recent failed runs._")
-    return "\n".join(lines)
+    body = '\n'.join(lines)
+    if len(body) <= MAX_COMMENT_LENGTH:
+        return body
+    suffix = '\n\n_… truncated to fit GitHub comment size limit._'
+    return body[: MAX_COMMENT_LENGTH - len(suffix)] + suffix
 
 
-def split_into_comments(table_body: str, max_length: int = DEFAULT_MAX_COMMENT_LENGTH) -> List[str]:
-    """Wrap ``table_body`` with header + LLM hint, splitting into multiple comments if needed.
-
-    Splits on table rows so each chunk stays valid markdown.
-    """
-    body = (table_body or '').strip()
-    prefix_overhead = len(_HEADER) + 1 + len(_LLM_HINT) + 1
-    if not body:
-        return [f"{_HEADER}\n{_LLM_HINT}"]
-
-    rows = body.split('\n')
-    # Header rows of the markdown table: title row + separator row.
-    if len(rows) >= 2 and rows[0].startswith('|') and set(rows[1].replace('|', '').strip()) <= {'-', ':', ' '}:
-        table_header = '\n'.join(rows[:2])
-        data_rows = rows[2:]
-    else:
-        table_header = ''
-        data_rows = rows
-
-    chunks: List[str] = []
-    current_rows: List[str] = []
-    current_len = 0
-    base_chunk_len = (len(table_header) + 1) if table_header else 0
-
-    def _flush() -> None:
-        nonlocal current_rows, current_len
-        if not current_rows:
-            return
-        block = '\n'.join(([table_header] if table_header else []) + current_rows)
-        chunks.append(block)
-        current_rows = []
-        current_len = 0
-
-    for row in data_rows:
-        row_len = len(row) + 1
-        if current_rows and (
-            prefix_overhead + base_chunk_len + current_len + row_len > max_length
-        ):
-            _flush()
-        current_rows.append(row)
-        current_len += row_len
-    _flush()
-
-    if not chunks:
-        chunks = [body]
-
-    if len(chunks) == 1:
-        return [f"{_HEADER}\n{_LLM_HINT}\n{chunks[0]}"]
-
-    total = len(chunks)
-    return [
-        f"{_HEADER} (part {idx}/{total})\n{_LLM_HINT}\n{chunk}"
-        for idx, chunk in enumerate(chunks, start=1)
-    ]
-
-
-def post_llm_debug_comment(
-    ydb_wrapper,
-    issue_id: str,
-    issue_url: str,
-    full_names: Sequence[str],
-    branch: str,
-    build_type: str,
-    *,
-    label: str = DEFAULT_LABEL,
-    window_days: int = DEFAULT_FAILURE_LOOKBACK_DAYS,
-    max_comment_length: int = DEFAULT_MAX_COMMENT_LENGTH,
-    job_names: Sequence[str] = DEFAULT_JOB_NAMES,
-) -> bool:
-    """Post the LLM-targeted debug-links comment(s) and attach the AI review label.
-
-    Best-effort: returns ``True`` when at least the comment was posted; logs and
-    returns ``False`` on any failure without raising.
-    """
-    if not issue_id:
-        logging.warning('post_llm_debug_comment: empty issue_id, skipping')
-        return False
-    full_names = [str(n) for n in full_names if n]
-    if not full_names:
-        return False
-
+def post_llm_debug_comment(ydb_wrapper, issue_id: str, issue_url: str,
+                           full_names: Sequence[str], branch: str, build_type: str) -> None:
+    """Post the debug-links comment and attach the AI review label. Best-effort."""
+    full_names = [n for n in full_names if n]
+    if not issue_id or not full_names:
+        return
     try:
-        debug_links = load_latest_failure_links(
-            ydb_wrapper,
-            branch=branch,
-            build_type=build_type,
-            full_names=full_names,
-            window_days=window_days,
-            job_names=job_names,
-        )
-        table_body = build_debug_links_table(full_names, debug_links, branch, build_type)
-        chunks = split_into_comments(table_body, max_length=max_comment_length)
-        for chunk in chunks:
-            add_issue_comment(issue_id, chunk)
+        rows = _load_latest_failures(ydb_wrapper, branch, build_type, full_names)
+        add_issue_comment(issue_id, _build_comment(full_names, rows, branch, build_type))
     except Exception as exc:
         logging.warning('Failed to post LLM debug comment to %s: %s', issue_url, exc)
-        return False
-
+        return
     try:
-        add_issue_label(issue_id, label)
+        add_issue_label(issue_id, AI_REVIEW_LABEL)
     except Exception as exc:
-        logging.warning('Failed to add label %r to %s: %s', label, issue_url, exc)
-    return True
+        logging.warning('Failed to add label %r to %s: %s', AI_REVIEW_LABEL, issue_url, exc)

--- a/.github/scripts/tests/mute/update_mute_issues.py
+++ b/.github/scripts/tests/mute/update_mute_issues.py
@@ -253,7 +253,7 @@ def create_and_add_issue_to_project(title, body, project_id=PROJECT_ID, org_name
         else:
             print(f"Error: Issue {title}: {issue_url}  not modified")
             return result
-    result = {'issue_url': issue_url, 'owner': owner, 'title': title}
+    result = {'issue_url': issue_url, 'issue_id': issue_id, 'owner': owner, 'title': title}
     return result
 
 
@@ -658,6 +658,54 @@ def add_issue_comment(issue_id, comment):
         print(f"Added comment to issue {issue_id}")
     else:
         print(f"Error: Failed to add comment to issue {issue_id}")
+
+def add_issue_label(issue_id, label_name):
+    """Attach a repository label to an issue by label name (idempotent on the GitHub side).
+
+    No-op (with a warning) when the label is missing in ``ORG_NAME/REPO_NAME``.
+    """
+    if not label_name:
+        return False
+
+    query_label = """
+    query ($org: String!, $repo: String!, $label: String!) {
+      organization(login: $org) {
+        repository(name: $repo) {
+          label(name: $label) {
+            id
+          }
+        }
+      }
+    }
+    """
+    label_result = run_query(
+        query_label,
+        {"org": ORG_NAME, "repo": REPO_NAME, "label": label_name},
+    )
+    label_id = (
+        ((label_result.get('data') or {}).get('organization') or {})
+        .get('repository', {})
+        .get('label', {})
+        .get('id')
+    )
+    if not label_id:
+        print(f"Warning: label {label_name!r} not found in {ORG_NAME}/{REPO_NAME}, skipping")
+        return False
+
+    mutation = """
+    mutation ($issueId: ID!, $labelId: ID!) {
+      addLabelsToLabelable(input: {labelableId: $issueId, labelIds: [$labelId]}) {
+        labelable { __typename }
+      }
+    }
+    """
+    result = run_query(mutation, {"issueId": issue_id, "labelId": label_id})
+    if result.get('errors'):
+        print(f"Error: failed to add label {label_name!r} to issue {issue_id}")
+        return False
+    print(f"Added label {label_name!r} to issue {issue_id}")
+    return True
+
 
 def update_issue_status(issue_id, status_field_id, status_option_id, issue_url):
     """Updates the status of an issue in the project.

--- a/.github/workflows/create_issues_for_muted_tests.yml
+++ b/.github/workflows/create_issues_for_muted_tests.yml
@@ -22,11 +22,6 @@ on:
             required: false
             type: string
             default: ''
-        add_debug_info:
-            description: 'Post LLM-targeted debug-links comment and attach AI review label to created issues'
-            required: false
-            type: boolean
-            default: true
 
 env:
   GH_TOKEN: ${{ secrets.YDBOT_TOKEN }}
@@ -118,18 +113,7 @@ jobs:
         id: create_issues
         env:
           GITHUB_TOKEN: ${{ env.GH_TOKEN }}
-        run: |
-          set -euo pipefail
-          # Default to posting the LLM debug-links comment unless the dispatcher disables it.
-          ADD_DEBUG_FLAG="--add_debug_info"
-          if [ "${{ github.event_name }}" = "workflow_dispatch" ] && [ "${{ github.event.inputs.add_debug_info }}" = "false" ]; then
-            ADD_DEBUG_FLAG="--no-add_debug_info"
-          fi
-          .github/scripts/tests/mute/create_new_muted_ya.py create_issues \
-            --file_path="${{ env.MUTED_YA_FILE_PATH }}" \
-            --branch=${{ env.BASE_BRANCH }} \
-            --build-type=${{ matrix.build_type }} \
-            "$ADD_DEBUG_FLAG"
+        run: .github/scripts/tests/mute/create_new_muted_ya.py create_issues --file_path="${{ env.MUTED_YA_FILE_PATH }}" --branch=${{ env.BASE_BRANCH }} --build-type=${{ matrix.build_type }}
 
       - name: Add issues to PR
         continue-on-error: true

--- a/.github/workflows/create_issues_for_muted_tests.yml
+++ b/.github/workflows/create_issues_for_muted_tests.yml
@@ -22,6 +22,11 @@ on:
             required: false
             type: string
             default: ''
+        add_debug_info:
+            description: 'Post LLM-targeted debug-links comment and attach AI review label to created issues'
+            required: false
+            type: boolean
+            default: true
 
 env:
   GH_TOKEN: ${{ secrets.YDBOT_TOKEN }}
@@ -113,7 +118,18 @@ jobs:
         id: create_issues
         env:
           GITHUB_TOKEN: ${{ env.GH_TOKEN }}
-        run: .github/scripts/tests/mute/create_new_muted_ya.py create_issues --file_path="${{ env.MUTED_YA_FILE_PATH }}" --branch=${{ env.BASE_BRANCH }} --build-type=${{ matrix.build_type }}
+        run: |
+          set -euo pipefail
+          # Default to posting the LLM debug-links comment unless the dispatcher disables it.
+          ADD_DEBUG_FLAG="--add_debug_info"
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ] && [ "${{ github.event.inputs.add_debug_info }}" = "false" ]; then
+            ADD_DEBUG_FLAG="--no-add_debug_info"
+          fi
+          .github/scripts/tests/mute/create_new_muted_ya.py create_issues \
+            --file_path="${{ env.MUTED_YA_FILE_PATH }}" \
+            --branch=${{ env.BASE_BRANCH }} \
+            --build-type=${{ matrix.build_type }} \
+            "$ADD_DEBUG_FLAG"
 
       - name: Add issues to PR
         continue-on-error: true


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Changelog entry

Newly created mute issues now get a comment with debug-links (latest failing CI run, stderr/stdout/log/logsdir, history dashboard) and an AI review label, so an LLM reviewer can pick them up with full context.

### Changelog category

* Not for changelog (changelog entry is not required)

### Description for reviewers

Focused, scalable replacement for the comment/label part of the now-stale #39512. Only touches the mute-issue creation path; nothing else from that PR is included.

#### What it does

When the `create_issues` worker creates a new mute issue, it always:

1. Queries `test_results` for the most recent `failure | error | mute` run of every test in that issue (last 7 days, restricted to the well-known long-running CI jobs, PR-manual reruns excluded).
2. Builds a markdown table per test with: status, error type, last-run timestamp, history dashboard link, GitHub run URL, and the four artifact links (`stderr`, `stdout`, `log`, `logsdir`).
3. Wraps the table in a hidden HTML hint asking an LLM reviewer to classify the failure (TEST/YDB/INFRA), find a likely root cause and offending commit, estimate severity and propose a fix.
4. Attaches the `needs-ai-review` label so a downstream AI workflow can find the issue.

Chunk tests never reach this code path — they are already filtered out earlier in `create_mute_issues` (`is_chunk_test` check), so no special handling is needed in the new module.

The whole flow is **best-effort**: any YDB / GitHub failure is logged and never raised. Issue creation cannot regress because of this annotation.

#### Layout

- New: `.github/scripts/tests/mute/llm_debug_comment.py` (~190 lines) — one public function `post_llm_debug_comment(...)`, the YDB query, the markdown builder.
- `update_mute_issues.py` — `create_and_add_issue_to_project` now also returns `issue_id`; new `add_issue_label(issue_id, label_name)` GraphQL helper.
- `create_new_muted_ya.py` — passes `ydb_wrapper` into `create_mute_issues`, calls `post_llm_debug_comment` after each successful issue creation. **No new CLI flags.**
- `.github/workflows/create_issues_for_muted_tests.yml` — **no changes**.

#### Why this design

- One small, single-purpose module, no opt-in plumbing through CLI/workflow.
- Defaults (`needs-ai-review` label, 7-day lookback, job allowlist) live in the module as constants — change one place.
- Best-effort posting means we can ship without coupling mute-issue creation to YDB/GitHub availability.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8faba815-b368-47ca-b77f-9686a0a1365d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8faba815-b368-47ca-b77f-9686a0a1365d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

