### PR TITLE
Fix fast-unmute grace race that caused re-mute after unmute

### DIFF
--- a/.github/scripts/tests/mute/create_new_muted_ya.py
+++ b/.github/scripts/tests/mute/create_new_muted_ya.py
@@ -38,6 +38,12 @@ from mute.constants import (
 from mute.naming import mute_file_line_to_tests_monitor_full_name
 from mute.mute_utils import dedicated_relative
 from mute.llm_debug_comment import post_llm_debug_comment
+from mute.fast_unmute_pipeline import grace_ttl_calendar_days
+from mute.fast_unmute_ydb import (
+    _coerce_dt,
+    create_fast_unmute_grace_table,
+    upsert_fast_unmute_grace_row,
+)
 from ydb_wrapper import YDBWrapper
 from github_issue_utils import DEFAULT_BUILD_TYPE, canonical_team_slug, make_profile_id
 
@@ -203,6 +209,101 @@ def delete_fast_unmute_grace_rows(ydb_wrapper, branch, build_type, test_strings)
                 full_name,
                 exc,
             )
+
+
+def load_fast_unmute_active_row_map(ydb_wrapper, branch, build_type):
+    """Map ``full_name`` -> fast_unmute_active row for this (branch, build_type)."""
+    try:
+        table_path = ydb_wrapper.get_table_path('fast_unmute_active')
+    except KeyError:
+        return {}
+
+    branch_esc = str(branch).replace("'", "''")
+    build_type_esc = str(build_type).replace("'", "''")
+    query = f"""
+    SELECT full_name, github_issue_number, requested_at
+    FROM `{table_path}`
+    WHERE branch = '{branch_esc}'
+        AND build_type = '{build_type_esc}'
+    """
+    try:
+        rows = ydb_wrapper.execute_scan_query(query, query_name='fast_unmute_active_load_rows')
+    except Exception as exc:
+        logging.warning('Failed to load fast_unmute_active rows: %s', exc)
+        return {}
+
+    out = {}
+    for row in rows:
+        fn = row.get('full_name')
+        if fn:
+            out[fn] = row
+    return out
+
+
+def record_fast_unmute_grace_for_unmute_lines(
+    ydb_wrapper,
+    branch,
+    build_type,
+    test_lines,
+    active_row_map,
+):
+    """Upsert ``fast_unmute_grace`` when fast-unmute decides to unmute.
+
+    Job 1 ``cleanup_manual_unmute`` only sees ``tests_monitor`` from the previous
+    workflow hour, so grace may be missing on the first run after unmute. Writing
+    grace here closes that gap before the next mute aggregation.
+    """
+    if not test_lines or not ydb_wrapper or not branch or not build_type:
+        return
+
+    try:
+        grace_table_path = ydb_wrapper.get_table_path('fast_unmute_grace')
+    except KeyError:
+        logging.info('fast_unmute_grace not registered — skip grace upsert on unmute')
+        return
+
+    create_fast_unmute_grace_table(ydb_wrapper, grace_table_path)
+    now = datetime.datetime.now(tz=datetime.timezone.utc)
+    grace_ttl = grace_ttl_calendar_days(get_mute_window_days(), get_manual_unmute_window_days())
+    recorded = 0
+
+    for line in test_lines:
+        if '*' in line or '?' in line:
+            continue
+        full_name = mute_file_line_to_tests_monitor_full_name(line)
+        active_row = active_row_map.get(full_name)
+        if not active_row:
+            logging.warning(
+                'fast-unmute grace: skip %r — no fast_unmute_active row for %s',
+                line,
+                full_name,
+            )
+            continue
+        requested_at = _coerce_dt(active_row.get('requested_at'))
+        fast_track_at = requested_at or now
+        try:
+            upsert_fast_unmute_grace_row(
+                ydb_wrapper,
+                grace_table_path,
+                full_name,
+                branch,
+                build_type,
+                int(active_row.get('github_issue_number') or 0),
+                fast_track_at,
+                now,
+                grace_ttl,
+            )
+            recorded += 1
+        except Exception as exc:
+            logging.warning('Failed to upsert fast-unmute grace for %s: %s', full_name, exc)
+
+    if recorded:
+        logging.info(
+            'Recorded fast-unmute grace for %d test(s) on branch=%s build_type=%s',
+            recorded,
+            branch,
+            build_type,
+        )
 
 
 def load_manual_unmute_full_names(ydb_wrapper, branch, build_type):
@@ -710,6 +811,7 @@ def apply_and_add_mutes(
     ydb_wrapper=None,
     branch=None,
     build_type=None,
+    fast_unmute_active_row_map=None,
 ):
     output_path = os.path.join(output_path, 'mute_update')
     logging.info(f"Creating mute files in directory: {output_path}")
@@ -835,6 +937,13 @@ def apply_and_add_mutes(
                 logging.info(
                     'Manual fast-unmute added %d test(s) to to_unmute [fast-unmute]',
                     len(to_unmute_manual_stable),
+                )
+                record_fast_unmute_grace_for_unmute_lines(
+                    ydb_wrapper,
+                    branch,
+                    build_type,
+                    to_unmute_manual_stable,
+                    fast_unmute_active_row_map or {},
                 )
             if manual_fast_delete_lines:
                 logging.info(
@@ -1482,10 +1591,14 @@ def mute_worker(args):
 
         manual_unmute_window_days, manual_unmute_min_runs = load_manual_unmute_config()
         manual_unmute_full_names = set()
+        fast_unmute_active_row_map = {}
         aggregated_for_manual_unmute = None
         if manual_unmute_window_days and manual_unmute_min_runs:
             manual_unmute_full_names = load_manual_unmute_full_names(ydb_wrapper, args.branch, build_type)
             if manual_unmute_full_names:
+                fast_unmute_active_row_map = load_fast_unmute_active_row_map(
+                    ydb_wrapper, args.branch, build_type
+                )
                 aggregated_for_manual_unmute = aggregate_test_data(all_data, manual_unmute_window_days)
                 logging.info(
                     f"Manual fast-unmute: window={manual_unmute_window_days}d, min_runs={manual_unmute_min_runs}, "
@@ -1537,6 +1650,7 @@ def mute_worker(args):
                 ydb_wrapper=ydb_wrapper,
                 branch=args.branch,
                 build_type=build_type,
+                fast_unmute_active_row_map=fast_unmute_active_row_map,
             )
 
         elif args.mode == 'sync_fast_unmute_grace':

--- a/.github/scripts/tests/mute/create_new_muted_ya.py
+++ b/.github/scripts/tests/mute/create_new_muted_ya.py
@@ -38,12 +38,7 @@ from mute.constants import (
 from mute.naming import mute_file_line_to_tests_monitor_full_name
 from mute.mute_utils import dedicated_relative
 from mute.llm_debug_comment import post_llm_debug_comment
-from mute.fast_unmute_pipeline import grace_ttl_calendar_days
-from mute.fast_unmute_ydb import (
-    _coerce_dt,
-    create_fast_unmute_grace_table,
-    upsert_fast_unmute_grace_row,
-)
+from mute.fast_unmute_pipeline import enter_fast_unmute_grace_for_unmuted_tests
 from ydb_wrapper import YDBWrapper
 from github_issue_utils import DEFAULT_BUILD_TYPE, canonical_team_slug, make_profile_id
 
@@ -209,101 +204,6 @@ def delete_fast_unmute_grace_rows(ydb_wrapper, branch, build_type, test_strings)
                 full_name,
                 exc,
             )
-
-
-def load_fast_unmute_active_row_map(ydb_wrapper, branch, build_type):
-    """Map ``full_name`` -> fast_unmute_active row for this (branch, build_type)."""
-    try:
-        table_path = ydb_wrapper.get_table_path('fast_unmute_active')
-    except KeyError:
-        return {}
-
-    branch_esc = str(branch).replace("'", "''")
-    build_type_esc = str(build_type).replace("'", "''")
-    query = f"""
-    SELECT full_name, github_issue_number, requested_at
-    FROM `{table_path}`
-    WHERE branch = '{branch_esc}'
-        AND build_type = '{build_type_esc}'
-    """
-    try:
-        rows = ydb_wrapper.execute_scan_query(query, query_name='fast_unmute_active_load_rows')
-    except Exception as exc:
-        logging.warning('Failed to load fast_unmute_active rows: %s', exc)
-        return {}
-
-    out = {}
-    for row in rows:
-        fn = row.get('full_name')
-        if fn:
-            out[fn] = row
-    return out
-
-
-def record_fast_unmute_grace_for_unmute_lines(
-    ydb_wrapper,
-    branch,
-    build_type,
-    test_lines,
-    active_row_map,
-):
-    """Upsert ``fast_unmute_grace`` when fast-unmute decides to unmute.
-
-    Job 1 ``cleanup_manual_unmute`` only sees ``tests_monitor`` from the previous
-    workflow hour, so grace may be missing on the first run after unmute. Writing
-    grace here closes that gap before the next mute aggregation.
-    """
-    if not test_lines or not ydb_wrapper or not branch or not build_type:
-        return
-
-    try:
-        grace_table_path = ydb_wrapper.get_table_path('fast_unmute_grace')
-    except KeyError:
-        logging.info('fast_unmute_grace not registered — skip grace upsert on unmute')
-        return
-
-    create_fast_unmute_grace_table(ydb_wrapper, grace_table_path)
-    now = datetime.datetime.now(tz=datetime.timezone.utc)
-    grace_ttl = grace_ttl_calendar_days(get_mute_window_days(), get_manual_unmute_window_days())
-    recorded = 0
-
-    for line in test_lines:
-        if '*' in line or '?' in line:
-            continue
-        full_name = mute_file_line_to_tests_monitor_full_name(line)
-        active_row = active_row_map.get(full_name)
-        if not active_row:
-            logging.warning(
-                'fast-unmute grace: skip %r — no fast_unmute_active row for %s',
-                line,
-                full_name,
-            )
-            continue
-        requested_at = _coerce_dt(active_row.get('requested_at'))
-        fast_track_at = requested_at or now
-        try:
-            upsert_fast_unmute_grace_row(
-                ydb_wrapper,
-                grace_table_path,
-                full_name,
-                branch,
-                build_type,
-                int(active_row.get('github_issue_number') or 0),
-                fast_track_at,
-                now,
-                grace_ttl,
-            )
-            recorded += 1
-        except Exception as exc:
-            logging.warning('Failed to upsert fast-unmute grace for %s: %s', full_name, exc)
-
-    if recorded:
-        logging.info(
-            'Recorded fast-unmute grace for %d test(s) on branch=%s build_type=%s',
-            recorded,
-            branch,
-            build_type,
-        )
 
 
 def load_manual_unmute_full_names(ydb_wrapper, branch, build_type):
@@ -811,7 +711,6 @@ def apply_and_add_mutes(
     ydb_wrapper=None,
     branch=None,
     build_type=None,
-    fast_unmute_active_row_map=None,
 ):
     output_path = os.path.join(output_path, 'mute_update')
     logging.info(f"Creating mute files in directory: {output_path}")
@@ -937,13 +836,6 @@ def apply_and_add_mutes(
                 logging.info(
                     'Manual fast-unmute added %d test(s) to to_unmute [fast-unmute]',
                     len(to_unmute_manual_stable),
-                )
-                record_fast_unmute_grace_for_unmute_lines(
-                    ydb_wrapper,
-                    branch,
-                    build_type,
-                    to_unmute_manual_stable,
-                    fast_unmute_active_row_map or {},
                 )
             if manual_fast_delete_lines:
                 logging.info(
@@ -1573,6 +1465,17 @@ def mute_worker(args):
             return 1
 
         build_type = getattr(args, 'build_type', DEFAULT_BUILD_TYPE)
+
+        if args.mode == 'enter_fast_unmute_grace':
+            logging.info(
+                'Starting enter_fast_unmute_grace for branch=%s build_type=%s',
+                args.branch,
+                build_type,
+            )
+            enter_fast_unmute_grace_for_unmuted_tests(ydb_wrapper, args.branch, build_type)
+            logging.info('enter_fast_unmute_grace completed successfully')
+            return 0
+
         logging.info(f"Starting mute worker with mode: {args.mode}")
         logging.info(f"Branch: {args.branch}")
         logging.info(f"build_type: {build_type}")
@@ -1591,14 +1494,10 @@ def mute_worker(args):
 
         manual_unmute_window_days, manual_unmute_min_runs = load_manual_unmute_config()
         manual_unmute_full_names = set()
-        fast_unmute_active_row_map = {}
         aggregated_for_manual_unmute = None
         if manual_unmute_window_days and manual_unmute_min_runs:
             manual_unmute_full_names = load_manual_unmute_full_names(ydb_wrapper, args.branch, build_type)
             if manual_unmute_full_names:
-                fast_unmute_active_row_map = load_fast_unmute_active_row_map(
-                    ydb_wrapper, args.branch, build_type
-                )
                 aggregated_for_manual_unmute = aggregate_test_data(all_data, manual_unmute_window_days)
                 logging.info(
                     f"Manual fast-unmute: window={manual_unmute_window_days}d, min_runs={manual_unmute_min_runs}, "
@@ -1650,7 +1549,6 @@ def mute_worker(args):
                 ydb_wrapper=ydb_wrapper,
                 branch=args.branch,
                 build_type=build_type,
-                fast_unmute_active_row_map=fast_unmute_active_row_map,
             )
 
         elif args.mode == 'sync_fast_unmute_grace':
@@ -1721,6 +1619,18 @@ if __name__ == "__main__":
     )
     sync_fast_unmute_grace_parser.add_argument('--branch', default='main', help='Branch to get history')
     sync_fast_unmute_grace_parser.add_argument(
+        '--build-type',
+        default=DEFAULT_BUILD_TYPE,
+        dest='build_type',
+        help='tests_monitor build_type slice (default: relwithdebinfo)',
+    )
+
+    enter_fast_unmute_grace_parser = subparsers.add_parser(
+        'enter_fast_unmute_grace',
+        help='start fast_unmute_grace when tests left mute on branch (after tests_monitor refresh)',
+    )
+    enter_fast_unmute_grace_parser.add_argument('--branch', default='main', help='Branch to get history')
+    enter_fast_unmute_grace_parser.add_argument(
         '--build-type',
         default=DEFAULT_BUILD_TYPE,
         dest='build_type',

--- a/.github/scripts/tests/mute/create_new_muted_ya.py
+++ b/.github/scripts/tests/mute/create_new_muted_ya.py
@@ -1473,7 +1473,12 @@ def mute_worker(args):
                 build_type,
             )
             enter_fast_unmute_grace_for_unmuted_tests(ydb_wrapper, args.branch, build_type)
-            logging.info('enter_fast_unmute_grace completed successfully')
+            logging.info(
+                'enter_fast_unmute_grace step finished for branch=%s build_type=%s '
+                '(see log above for recorded/skipped rows and any warnings)',
+                args.branch,
+                build_type,
+            )
             return 0
 
         logging.info(f"Starting mute worker with mode: {args.mode}")

--- a/.github/scripts/tests/mute/fast_unmute_pipeline.py
+++ b/.github/scripts/tests/mute/fast_unmute_pipeline.py
@@ -50,6 +50,8 @@ from mute.fast_unmute_ydb import (
     fetch_all_rows,
     fetch_candidate_issues,
     fetch_currently_muted,
+    fetch_fast_unmute_active_rows,
+    fetch_grace_full_names,
     upsert_fast_unmute_grace_row,
     upsert_rows,
 )
@@ -77,6 +79,97 @@ def grace_ttl_calendar_days(mute_window_days, manual_unmute_window_days):
     Stored on insert so dashboards and TTL stay interpretable even if ``mute_config.json`` changes later.
     """
     return max(1, int(mute_window_days) - int(manual_unmute_window_days))
+
+
+def enter_fast_unmute_grace_for_unmuted_tests(ydb_wrapper, branch, build_type):
+    """Start grace when fast-unmute tests are no longer muted on branch (merged ``muted_ya``).
+
+    Runs in Job 2 after ``tests_monitor`` refresh so ``grace_started_at`` reflects the actual
+    unmute on main, not the hour when an unmute PR was opened (that PR may merge much later).
+    """
+    try:
+        active_table_path = ydb_wrapper.get_table_path('fast_unmute_active')
+        grace_table_path = ydb_wrapper.get_table_path('fast_unmute_grace')
+        tests_monitor_path = ydb_wrapper.get_table_path('tests_monitor')
+    except KeyError:
+        logging.info('fast_unmute tables not configured — skip enter_fast_unmute_grace')
+        return
+
+    create_fast_unmute_grace_table(ydb_wrapper, grace_table_path)
+
+    try:
+        active_rows = fetch_fast_unmute_active_rows(
+            ydb_wrapper, active_table_path, branch, build_type
+        )
+    except Exception as exc:
+        logging.warning('enter_fast_unmute_grace: failed to load fast_unmute_active: %s', exc)
+        return
+
+    if not active_rows:
+        logging.info(
+            'enter_fast_unmute_grace: no fast_unmute_active rows for branch=%s build_type=%s',
+            branch,
+            build_type,
+        )
+        return
+
+    try:
+        currently_muted = fetch_currently_muted(
+            ydb_wrapper, tests_monitor_path, branch, build_type
+        )
+        existing_grace = fetch_grace_full_names(
+            ydb_wrapper, grace_table_path, branch, build_type
+        )
+    except Exception as exc:
+        logging.warning('enter_fast_unmute_grace: failed to load monitor/grace state: %s', exc)
+        return
+
+    now = datetime.datetime.now(tz=datetime.timezone.utc)
+    grace_ttl = grace_ttl_calendar_days(
+        get_mute_window_days(), get_manual_unmute_window_days()
+    )
+    recorded = 0
+
+    for row in active_rows:
+        full_name = row.get('full_name')
+        if not full_name or full_name in currently_muted:
+            continue
+        if full_name in existing_grace:
+            continue
+        requested_at = _coerce_dt(row.get('requested_at'))
+        try:
+            upsert_fast_unmute_grace_row(
+                ydb_wrapper,
+                grace_table_path,
+                full_name,
+                branch,
+                build_type,
+                int(row.get('github_issue_number') or 0),
+                requested_at or now,
+                now,
+                grace_ttl,
+            )
+            recorded += 1
+            logging.info(
+                'enter_fast_unmute_grace: started grace for %s (branch=%s build_type=%s)',
+                full_name,
+                branch,
+                build_type,
+            )
+        except Exception as exc:
+            logging.warning(
+                'enter_fast_unmute_grace: failed to upsert grace for %s: %s',
+                full_name,
+                exc,
+            )
+
+    if recorded:
+        logging.info(
+            'enter_fast_unmute_grace: recorded grace for %d test(s) on branch=%s build_type=%s',
+            recorded,
+            branch,
+            build_type,
+        )
 
 
 def load_config():
@@ -373,6 +466,19 @@ def cleanup_manual_unmute(ydb_wrapper, table_path, tests_monitor_path):
 
     for (branch, build_type), group_rows in grouped.items():
         currently_muted = fetch_currently_muted(ydb_wrapper, tests_monitor_path, branch, build_type)
+        existing_grace = set()
+        if grace_table_path:
+            try:
+                existing_grace = fetch_grace_full_names(
+                    ydb_wrapper, grace_table_path, branch, build_type
+                )
+            except Exception as exc:
+                logging.warning(
+                    'manual_unmute_cleanup: failed to load grace names for %s/%s: %s',
+                    branch,
+                    build_type,
+                    exc,
+                )
         for row in group_rows:
             full_name = row.get('full_name')
             if not full_name:
@@ -381,7 +487,7 @@ def cleanup_manual_unmute(ydb_wrapper, table_path, tests_monitor_path):
             issue_number = row.get('github_issue_number')
 
             if full_name not in currently_muted:
-                if grace_table_path:
+                if grace_table_path and full_name not in existing_grace:
                     try:
                         ft_at = requested_at or now
                         upsert_fast_unmute_grace_row(

--- a/.github/scripts/tests/mute/fast_unmute_ydb.py
+++ b/.github/scripts/tests/mute/fast_unmute_ydb.py
@@ -131,7 +131,7 @@ def fetch_fast_unmute_active_rows(ydb_wrapper, table_path, branch, build_type):
     WHERE branch = '{br}'
         AND build_type = '{bt}'
     """
-    return ydb_wrapper.execute_scan_query(query, query_name='fast_unmute_active_fetch_profile')
+    return ydb_wrapper.execute_scan_query(query, query_name='fast_unmute_active_fetch')
 
 
 def fetch_grace_full_names(ydb_wrapper, table_path, branch, build_type):

--- a/.github/scripts/tests/mute/fast_unmute_ydb.py
+++ b/.github/scripts/tests/mute/fast_unmute_ydb.py
@@ -122,6 +122,31 @@ def fetch_currently_muted(ydb_wrapper, tests_monitor_path, branch, build_type):
     return result
 
 
+def fetch_fast_unmute_active_rows(ydb_wrapper, table_path, branch, build_type):
+    br = _escape(branch)
+    bt = _escape(build_type)
+    query = f"""
+    SELECT full_name, github_issue_number, requested_at
+    FROM `{table_path}`
+    WHERE branch = '{br}'
+        AND build_type = '{bt}'
+    """
+    return ydb_wrapper.execute_scan_query(query, query_name='fast_unmute_active_fetch_profile')
+
+
+def fetch_grace_full_names(ydb_wrapper, table_path, branch, build_type):
+    br = _escape(branch)
+    bt = _escape(build_type)
+    query = f"""
+    SELECT full_name
+    FROM `{table_path}`
+    WHERE branch = '{br}'
+        AND build_type = '{bt}'
+    """
+    rows = ydb_wrapper.execute_scan_query(query, query_name='fast_unmute_grace_fetch_names')
+    return {row['full_name'] for row in rows if row.get('full_name')}
+
+
 def create_fast_unmute_grace_table(ydb_wrapper, table_path):
     create_sql = f"""
     CREATE TABLE IF NOT EXISTS `{table_path}` (

--- a/.github/workflows/update_muted_ya.yml
+++ b/.github/workflows/update_muted_ya.yml
@@ -131,6 +131,12 @@ jobs:
       - name: Update test monitor
         run: python3 .github/scripts/analytics/tests_monitor.py --branch=${{ env.BASE_BRANCH }} --build_type=${{ env.BUILD_TYPE }}
 
+      - name: Record fast-unmute grace for tests unmuted on branch
+        run: |
+          .github/scripts/tests/mute/create_new_muted_ya.py enter_fast_unmute_grace \
+            --branch=${{ env.BASE_BRANCH }} \
+            --build-type=${{ env.BUILD_TYPE }}
+
       - name: Sync fast-unmute grace for re-muted tests
         run: |
           .github/scripts/tests/mute/create_new_muted_ya.py sync_fast_unmute_grace \


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes ydb-platform/ydb#45582

## Problem

After a successful fast-unmute, tests could be **re-muted on the next hourly run** even though the grace ladder was designed to prevent that.

Example: `TGRpcCmsTest.AlterRemoveTest` on 2026-07-05 — unmuted at 01:06 UTC, re-muted at 01:57 UTC (issue #45555).

## Root cause

Grace rows (`fast_unmute_grace`) were only inserted in Job 1 (`manual_unmute.py sync`) when `tests_monitor` already showed `is_muted=0`. Job 1 runs **before** Job 2 and reads monitor state from the **previous** hour, so on the first run after unmute PR merge grace was often missing → full **4-day** mute window → re-mute.

## Why not grace at unmute PR creation?

An earlier approach wrote grace when `update_muted_ya` **decides** to unmute. That is wrong: the mute PR may merge hours or days later, so `grace_started_at` must reflect **actual** unmute on `main`, not PR open time.

## Fix

New Job 2 step **after** `tests_monitor` refresh (reflects merged `muted_ya` on branch):

```
enter_fast_unmute_grace → sync_fast_unmute_grace → update_muted_ya
```

`enter_fast_unmute_grace_for_unmuted_tests`:
- For `fast_unmute_active` rows where fresh monitor shows `is_muted=0`
- Insert `fast_unmute_grace` with `grace_started_at = now` (actual unmute)
- Skip if grace row already exists (idempotent with Job 1 cleanup)

Job 1 `cleanup_manual_unmute` also skips grace upsert when row already exists, so it won't reset `grace_started_at`.

## Alternatives considered

### Why not fix it in `create_issues_for_muted_tests.yml`?

That merge-triggered workflow already has the right ordering: job `create-issues-for-muted-tests` refreshes `tests_monitor`, then job `sync-manual-fast-unmute` (`needs:` the first) writes grace via `manual_unmute.py sync`. It is still not sufficient:
- the grace write lags the monitor refresh by a **separate job** (new runner + `pip install` + `export_issues_to_ydb`) — during that gap the monitor already reads `is_muted=0` while grace is still empty;
- the re-mute decision is made by a **different** workflow (`update_muted_ya.yml`) that runs on schedule **independently and concurrently**, and refreshes `tests_monitor` on its own. There is no ordering guarantee between the two workflows → the hourly run can read an empty `grace_map` before the merge-workflow writes grace (exactly the 01:06 → 01:57 case).

The only race-free point is co-locating the grace write immediately before its read, in the same `update_muted_ya.yml` job, right after the same `tests_monitor` refresh.

### Why a dedicated function instead of reusing existing ones?

- `cleanup_manual_unmute` (Job 1) also writes grace, but it cannot be called from Job 2: it performs GitHub side effects (reopen / comment / label / project-status), operates **globally** across all `(branch, build_type)`, and deletes `fast_unmute_active` rows. Job 2 is a per-`build_type` matrix (N parallel legs) → duplicate/racing GitHub calls and premature row deletion. The lifecycle is deliberately kept as a single point in Job 1.
- `sync_fast_unmute_grace` does the opposite — it **deletes** grace rows for tests that became mute candidates again; it cannot create grace.
- So `enter_fast_unmute_grace` is a narrow, idempotent, GitHub-free writer that reuses the low-level building blocks (`fetch_currently_muted`, `upsert_fast_unmute_grace_row`, `grace_ttl_calendar_days`). Only two queries are new: `fetch_fast_unmute_active_rows` (filtered by `branch`/`build_type` — the existing `fetch_all_rows` is global) and `fetch_grace_full_names` (idempotency guard so `grace_started_at` is not reset).

## Testing

- `python3 -m py_compile` on modified mute scripts
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f31a7-9902-76bb-9b27-dfad0f3b07a0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f31a7-9902-76bb-9b27-dfad0f3b07a0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>


